### PR TITLE
GH-171 Resizing surface while menu is open causes title bar to resize

### DIFF
--- a/widgets/src/common/Menu.js
+++ b/widgets/src/common/Menu.js
@@ -17,14 +17,6 @@
         this.padding(0);
 
         var context = this;
-        d3.select("body")
-            .on("click." + this._id, function () {
-                console.log("click:  body - " + context._id)
-                if (context._visible) {
-                    context.hideMenu();
-                }
-            })
-        ;
         this._list.click = function (d) {
             d3.event.stopPropagation();
             context.hideMenu();
@@ -60,9 +52,21 @@
         this._list
             .move(pos)
         ;
+        var context = this;
+        d3.select("body")
+            .on("click." + this._id, function () {
+                console.log("click:  body - " + context._id)
+                if (context._visible) {
+                    context.hideMenu();
+                }
+            })
+        ;
     };
 
     Menu.prototype.hideMenu = function () {
+        d3.select("body")
+            .on("click." + this._id, null)
+        ;
         this._visible = false;
         this._list
             .data([])

--- a/widgets/src/common/Surface.js
+++ b/widgets/src/common/Surface.js
@@ -9,6 +9,7 @@
         SVGWidget.call(this);
         this._class = "common_Surface";
 
+        this._menuPadding = 2;
         this._icon = new Icon()
             .padding(4)
         ;
@@ -25,7 +26,7 @@
         ;
         this._menu = new Menu()
             .faChar("\uf0c9")
-            .padding(4)
+            .padding(0)
         ;
         var context = this;
         this._menu.preShowMenu = function () {
@@ -142,7 +143,7 @@
         ;
         var iconClientSize = this._icon.getBBox(true);
         var textClientSize = this._text.getBBox(true);
-        var menuClientSize = this._menu.getBBox(true);
+        var menuClientSize = this._menu._faChar.getBBox(true);
         var titleRegionHeight = Math.max(iconClientSize.height, textClientSize.height, menuClientSize.height);
         var yTitle = (-this._size.height + titleRegionHeight) / 2;
 
@@ -162,7 +163,7 @@
             .move({ x: -this._size.width / 2 + iconClientSize.width / 2, y: yTitle })
         ;
         this._menu
-            .move({ x: this._size.width / 2 - menuClientSize.width / 2, y: yTitle })
+            .move({ x: this._size.width / 2 - menuClientSize.width / 2 - this._menuPadding, y: yTitle })
         ;
         this._text
             .move({ x: (iconClientSize.width / 2 - menuClientSize.width / 2) / 2, y: yTitle })

--- a/widgets/src/graph/Graph.js
+++ b/widgets/src/graph/Graph.js
@@ -379,11 +379,9 @@
                 context._selection.click(d, d3.event);
             })
             .on("click", function (d) {
-                d3.event.stopPropagation();
                 context.vertex_click(d, d3.event);
             })
             .on("dblclick", function (d) {
-                d3.event.stopPropagation();
                 context.vertex_dblclick(d, d3.event);
             })
             .on("mouseover", function (d) {


### PR DESCRIPTION
Only listen for body events while menu is visible.
No reason for vertex clicks to prevent propagation.

Fixes #171

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>