### PR TITLE
Re-factor palette to global singletons

### DIFF
--- a/demos/dermatology.html
+++ b/demos/dermatology.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>HPCC Systems - Dermatology Test</title>
-    <link rel="stylesheet" href="test.css">
+    <link rel="stylesheet" href="test.css" />
     <script src="../widgets/lib/requirejs/require.js"></script>
     <script src="../widgets/config.js"></script>
     <script>
@@ -29,6 +29,8 @@
             <option value="src/c3/Column">C3 Column</option>
             <option value="src/c3/Donut">C3 Donut</option>
             <option value="src/c3/Gauge">C3 Gauge</option>
+            <option value="src/map/ChoroplethStates">US States</option>
+            <option value="src/map/ChoroplethCounties">US Counties</option>
         </select>
     </p>
     <table style="width:auto">
@@ -40,7 +42,7 @@
         </thead>
         <tbody>
             <tr>
-                <td align="center">
+                <td align="center" valign="top">
                     <table border="0">
                         <tbody>
                             <tr>
@@ -145,6 +147,8 @@
                 td.appendChild(document.createTextNode("data_columns"));
                 td = tr.appendChild(document.createElement('td'));
                 var input = td.appendChild(document.createElement("textarea"));
+                input.setAttribute("rows", "4");
+                input.setAttribute("cols", "25");
                 input.value = JSON.stringify(sourceWidget._columns);
                 input.onchange = function () {
                     sourceWidget
@@ -161,6 +165,8 @@
                 td.appendChild(document.createTextNode("data_data"));
                 td = tr.appendChild(document.createElement('td'));
                 var input2 = td.appendChild(document.createElement("textarea"));
+                input2.setAttribute("rows", "4");
+                input2.setAttribute("cols", "25");
                 input2.value = JSON.stringify(sourceWidget._data);
                 input2.onchange = function () {
                     sourceWidget
@@ -173,7 +179,7 @@
                     ;
                 }
             }
-            testWidget = function(widgetPath) {
+            testWidget = function (widgetPath) {
                 require([widgetPath], function (Widget) {
                     document.getElementById("source").innerHTML = "";
                     var sourceWidget = new Widget()

--- a/demos/graph/index.html
+++ b/demos/graph/index.html
@@ -241,6 +241,7 @@
                 .highlightOnMouseOverVertex(true)
             ;
             graph.vertex_dblclick = function (d) {
+                d3.event.stopPropagation();
                 callService(d._id, d.element());
             };
             graph.vertex_click = function (d) {

--- a/widgets/src/c3/Column.js
+++ b/widgets/src/c3/Column.js
@@ -10,6 +10,7 @@
         this._class = "c3_Column";
 
         this._type = "bar";
+        this._prevRows = [];
     };
     Column.prototype = Object.create(Common2D.prototype);
 
@@ -18,8 +19,12 @@
         
         this.c3Chart.load({
             categories: this.getC3Categories(),
-            rows: this.getC3Rows()
+            rows: this.getC3Rows(),
+            unload: this._prevRows.map(function (row) {
+                return row[0];  //TODO Check if it is in new data
+            })
         });
+        this._prevRows = this._data;
     };
 
     return Column;

--- a/widgets/src/c3/Common.js
+++ b/widgets/src/c3/Common.js
@@ -1,13 +1,12 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "c3/c3", "../common/HTMLWidget", "../common/Palette", "css!c3/c3"], factory);
+        define(["d3/d3", "c3/c3", "../common/HTMLWidget", "css!c3/c3"], factory);
     } else {
-        root.Pie = factory(root.d3, root.c3, root.HTMLWidget, root.Palette);
+        root.Pie = factory(root.d3, root.c3, root.HTMLWidget);
     }
-}(this, function (d3, c3, HTMLWidget, Palette) {
+}(this, function (d3, c3, HTMLWidget) {
     function Common(target) {
         HTMLWidget.call(this);
-        this.d3Color = Palette.ordinal("category20");
 
         this._tag = "div";
         this._class = "c3_Common";
@@ -27,9 +26,6 @@
                 position: 'bottom',
                 show: true
             },
-            color: {
-                pattern: d3.scale.category20().range()
-            },
             data: {
                 columns: [],
                 rows: []
@@ -37,8 +33,6 @@
         };
     };
     Common.prototype = Object.create(HTMLWidget.prototype);
-
-    Common.prototype.d3Color = Palette.ordinal("category20");
 
     Common.prototype.type = function (_) {
         if (!arguments.length) return this._type;

--- a/widgets/src/c3/Common2D.js
+++ b/widgets/src/c3/Common2D.js
@@ -11,12 +11,26 @@
         this._class = "c3_Common2D";
 
         var context = this;
+        this._config.color = {
+            pattern: this._palette.colors()
+        };
+
         this._config.data.onclick = function (d, element) {
             context.click(context.rowToObj(context._data[d.index]), d.x ? d.id : context._columns[1]);
+        };
+        this._config.data.color = function (color, d) {
+            return context._palette(d.id ? d.id : d);
         };
     };
     Common2D.prototype = Object.create(Common.prototype);
     Common2D.prototype.implements(I2DChart.prototype);
+
+    Common2D.prototype.publish("paletteID", "default", "set", "Palette ID", Common2D.prototype._palette.switch());
+
+    Common2D.prototype.update = function (domNode, element) {
+        Common.prototype.update.apply(this, arguments);
+        this._palette = this._palette.switch(this._paletteID);
+    };
 
     return Common2D;
 }));

--- a/widgets/src/c3/Gauge.js
+++ b/widgets/src/c3/Gauge.js
@@ -18,6 +18,9 @@
             clickEvent[d.id] = d.value;
             context.click(clickEvent, d.id);
         };
+        this._config.data.color = function (color, d) {
+            return context._palette(context._data, context._low, context._high);
+        };
     };
     Gauge.prototype = Object.create(Common.prototype);
     Gauge.prototype.implements(I1DChart.prototype);
@@ -25,12 +28,14 @@
     Gauge.prototype.publish("low", 0, "number", "Gauge lower bound");
     Gauge.prototype.publish("high", 100, "number", "Gauge higher bound");
     Gauge.prototype.publish("value_format", "Percent", "set", "Value Display Format", ["Percent", "Value"]);
-    Gauge.prototype.publish("arc_width", 75, "number", "Gauge width of arc");
+    Gauge.prototype.publish("arc_width", 50, "number", "Gauge width of arc");
     Gauge.prototype.publish("show_labels", true, "boolean", "Show Labels");
     Gauge.prototype.publish("show_value_label", true, "boolean", "Show Value Label");
+    Gauge.prototype.publish("paletteID", "RdYlGn", "set", "Palette ID", Gauge.prototype._palette.switch());
 
     Gauge.prototype.update = function (domNode, element) {
         Common.prototype.update.apply(this, arguments);
+        this._palette = this._palette.switch(this._paletteID);
 
         this.c3Chart.internal.config.gauge_min = this.low();
         this.c3Chart.internal.config.gauge_max = this.high();

--- a/widgets/src/c3/Line.js
+++ b/widgets/src/c3/Line.js
@@ -10,16 +10,21 @@
         this._class = "c3_Line";
 
         this._type = "line";
+        this._prevRows = [];
     };
     Line.prototype = Object.create(Common2D.prototype);
 
     Line.prototype.update = function (domNode, element) {
         Common2D.prototype.update.apply(this, arguments);
-        
+
         this.c3Chart.load({
             categories: this.getC3Categories(),
-            rows: this.getC3Rows()
+            rows: this.getC3Rows(),
+            unload: this._prevRows.map(function (row) {
+                return row[0];  //TODO Check if it is in new data
+            })
         });
+        this._prevRows = this._data;
     };
 
     return Line;

--- a/widgets/src/chart/Bubble.js
+++ b/widgets/src/chart/Bubble.js
@@ -1,10 +1,10 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "../common/SVGWidget", "./I2DChart", "../common/Palette", "../common/Text", "../common/FAChar", "css!./Bubble"], factory);
+        define(["d3/d3", "../common/SVGWidget", "./I2DChart", "../common/Text", "../common/FAChar", "css!./Bubble"], factory);
     } else {
-        root.Bubble = factory(root.d3, root.SVGWidget, root.I2DChart, root.Palette, root.Text, root.FAChar);
+        root.Bubble = factory(root.d3, root.SVGWidget, root.I2DChart, root.Text, root.FAChar);
     }
-}(this, function (d3, SVGWidget, I2DChart, Palette, Text, FAChar) {
+}(this, function (d3, SVGWidget, I2DChart, Text, FAChar) {
     function Bubble(target) {
         SVGWidget.call(this);
         I2DChart.call(this);
@@ -20,8 +20,6 @@
     };
     Bubble.prototype = Object.create(SVGWidget.prototype);
     Bubble.prototype.implements(I2DChart.prototype);
-
-    Bubble.prototype.d3Color = Palette.ordinal("category20");
 
     Bubble.prototype.size = function (_) {
         var retVal = SVGWidget.prototype.size.apply(this, arguments);
@@ -51,7 +49,7 @@
                 var element = d3.select(this);
                 element.append("circle")
                     .attr("r", function (d) { return d.r; })
-                    .style("fill", function (d) { return context.d3Color(d[0]); })
+                    .style("fill", function (d) { return context._palette(d[0]); })
                     .append("title")
                 ;
                 if (d.__viz_faChar) {

--- a/widgets/src/chart/Column.js
+++ b/widgets/src/chart/Column.js
@@ -34,6 +34,7 @@
             .attr("width", this.x.rangeBand())
             .attr("y", function (d) { return context.y(d[1]); })
             .attr("height", function (d) { return height - context.y(d[1]); })
+            .style("fill", function (d) { return context._palette(d[0]); })
         ;
 
         title

--- a/widgets/src/chart/I1DChart.js
+++ b/widgets/src/chart/I1DChart.js
@@ -1,12 +1,13 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define([], factory);
+        define(["../common/Palette"], factory);
     } else {
-        root.I1DChart = factory();
+        root.I1DChart = factory(root.Palette);
     }
-}(this, function () {
+}(this, function (Palette) {
     function I1DChart() {
     };
+    I1DChart.prototype._palette = Palette.rainbow("default");
 
     //  Data ---
     I1DChart.prototype.testData = function () {

--- a/widgets/src/chart/I2DChart.js
+++ b/widgets/src/chart/I2DChart.js
@@ -1,12 +1,13 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define([], factory);
+        define(["../common/Palette"], factory);
     } else {
-        root.I2DChart = factory();
+        root.I2DChart = factory(root.Palette);
     }
-}(this, function () {
+}(this, function (Palette) {
     function I2DChart() {
     };
+    I2DChart.prototype._palette = Palette.ordinal("default");
 
     //  Data ---
     I2DChart.prototype.testData = function () {
@@ -19,9 +20,6 @@
         ]);
         return this;
     };
-
-    //  Properties  ---
-    //TODO:  I2DChart.prototype._palette = "category20";
 
     //  Events  ---
     I2DChart.prototype.click = function (row, column) {

--- a/widgets/src/chart/Line.js
+++ b/widgets/src/chart/Line.js
@@ -1,10 +1,10 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "./XYAxis", "./I2DChart", "../common/Palette", "css!./Line"], factory);
+        define(["d3/d3", "./XYAxis", "./I2DChart", "css!./Line"], factory);
     } else {
-        root.Line = factory(root.d3, root.XYAxis, root.I2DChart, root.Palette);
+        root.Line = factory(root.d3, root.XYAxis, root.I2DChart);
     }
-}(this, function (d3, XYAxis, I2DChart, Palette) {
+}(this, function (d3, XYAxis, I2DChart) {
     function Line(target) {
         XYAxis.call(this);
         I2DChart.call(this);
@@ -12,8 +12,6 @@
     };
     Line.prototype = Object.create(XYAxis.prototype);
     Line.prototype.implements(I2DChart.prototype);
-
-    Line.prototype.d3Color = Palette.ordinal("category20");
 
     Line.prototype.enter = function (domNode, element) {
         XYAxis.prototype.enter.apply(this, arguments);
@@ -40,7 +38,7 @@
         line.enter().append("path")
             .attr("class", "dataLine")
             .style("stroke", function (d, i) {
-                return context.d3Color(context._columns[i + 1]);
+                return context._palette(context._columns[i + 1]);
             })
             .append("title")
             .text(function(d) { return d; })

--- a/widgets/src/chart/MultiChart.js
+++ b/widgets/src/chart/MultiChart.js
@@ -1,10 +1,10 @@
 ﻿(function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "../common/SVGWidget", "./I2DChart", "../common/Palette"], factory);
+        define(["d3/d3", "../common/SVGWidget", "./I2DChart"], factory);
     } else {
-        root.MultiChart = factory(root.d3, root.SVGWidget, root.I2DChart, root.Palette);
+        root.MultiChart = factory(root.d3, root.SVGWidget, root.I2DChart);
     }
-}(this, function (d3, SVGWidget, I2DChart, Palette) {
+}(this, function (d3, SVGWidget, I2DChart) {
     function MultiChart() {
         SVGWidget.call(this);
         I2DChart.call(this);

--- a/widgets/src/chart/MultiChartSurface.js
+++ b/widgets/src/chart/MultiChartSurface.js
@@ -1,10 +1,10 @@
 ﻿(function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "../common/ResizeSurface", "./MultiChart", "./I2DChart", "../common/Palette"], factory);
+        define(["d3/d3", "../common/ResizeSurface", "./MultiChart", "./I2DChart"], factory);
     } else {
-        root.MultiChartSurface = factory(root.d3, root.ResizeSurface, root.MultiChart, root.I2DChart, root.Palette);
+        root.MultiChartSurface = factory(root.d3, root.ResizeSurface, root.MultiChart, root.I2DChart);
     }
-}(this, function (d3, ResizeSurface, MultiChart, I2DChart, Palette) {
+}(this, function (d3, ResizeSurface, MultiChart, I2DChart) {
     function MultiChartSurface() {
         ResizeSurface.call(this);
         I2DChart.call(this);
@@ -12,6 +12,10 @@
 
         this._title = "MultiChartSurface";
         this._content = new MultiChart();
+        this._content.click = function (d) {
+            context.click(d);
+        }
+
         var context = this;
         this._menu.click = function (d) {
             context._content.chartType(d);

--- a/widgets/src/chart/Pie.js
+++ b/widgets/src/chart/Pie.js
@@ -1,10 +1,10 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "../common/SVGWidget", "../common/Palette", "./I2DChart", "../common/Text", "../common/FAChar", "css!./Pie"], factory);
+        define(["d3/d3", "../common/SVGWidget", "./I2DChart", "../common/Text", "../common/FAChar", "css!./Pie"], factory);
     } else {
-        root.Pie = factory(root.d3, root.SVGWidget, root.Palette, root.I2DChart, root.Text, root.FAChar);
+        root.Pie = factory(root.d3, root.SVGWidget, root.I2DChart, root.Text, root.FAChar);
     }
-}(this, function (d3, SVGWidget, Palette, I2DChart, Text, FAChar) {
+}(this, function (d3, SVGWidget, I2DChart, Text, FAChar) {
     function Pie(target) {
         SVGWidget.call(this);
         I2DChart.call(this);
@@ -29,8 +29,6 @@
     };
     Pie.prototype = Object.create(SVGWidget.prototype);
     Pie.prototype.implements(I2DChart.prototype);
-
-    Pie.prototype.d3Color = Palette.ordinal("category20");
 
     Pie.prototype.size = function (_) {
         var retVal = SVGWidget.prototype.size.apply(this, arguments);
@@ -79,7 +77,7 @@
             .each(function (d) {
                 var element = d3.select(this);
                 element.append("path")
-                    .style("fill", function (d) { return context.d3Color(d.data[0]); })
+                    .style("fill", function (d) { return context._palette(d.data[0]); })
                     .attr("d", context.d3Arc)
                     .append("title")
                 ;

--- a/widgets/src/common/Palette.js
+++ b/widgets/src/common/Palette.js
@@ -5,105 +5,225 @@
         root.Entity = factory(root.d3);
     }
 }(this, function (d3) {
-    var sets = [
-        "category10", "category20", "category20b", "category20c",
+    var d3Ordinal = [
+        "category10", "category20", "category20b", "category20c"
+    ];
+    var brewerOrdinal = [
         "Accent", "Dark2", "Paired", "Pastel1", "Pastel2", "Set1", "Set2", "Set3"
     ];
-    
-    ordinal = function (palette) {
-        if (!arguments.length) return sets;
-        if (d3.scale[palette]) {
-            return d3.scale[palette]();
-        } else if (colorbrewer[palette]) {
-            var largestPalette = 12;
-            while (largestPalette > 0) {
-                if (colorbrewer[palette][largestPalette]) {
-                    return d3.scale.ordinal().range(colorbrewer[palette][largestPalette]);
-                }
-                --largestPalette;
-            }
+    var hpccOrdinal = [
+        "hpcc10", "hpcc20"
+    ];
+
+    var ordinalCache = {};
+
+    function fetchOrdinalItem(id, colors) {
+        if (!id) return palette_ordinal();
+        var retVal = ordinalCache[id];
+        if (!retVal) {
+            retVal = palette_ordinal(id, colors);
+            ordinalCache[id] = retVal;
         }
-        throw "Invalid color palette:  " + palette;
+        return retVal;
     };
 
-    brewer = function (palette, from, to) {
+    function palette_ordinal(id, colors) {
+        if (!id) return ["default"].concat(d3Ordinal.concat(brewerOrdinal).concat(hpccOrdinal));
+        var id = id;
+        var scale = null;
+        var colors = colors;
+
+        if (colors) {
+            scale = d3.scale.ordinal().range(colors);
+        } else {
+            if (d3Ordinal.indexOf(id) >= 0) {
+                scale = new d3.scale[id]();
+            } else if (hpccOrdinal.indexOf(id) >= 0) {
+                var newColors = []
+                switch (id) {
+                    case "hpcc10":
+                        var colors = palette_ordinal("default").colors();
+                        newColors = colors.filter(function (item, idx) {
+                            if (idx % 2) {
+                                return true;
+                            }
+                            return false;
+                        });
+                        break;
+                    case "hpcc20":
+                        newColors = palette_ordinal("category10").colors().concat(palette_ordinal("hpcc10").colors());
+                        break;
+                }
+                scale = d3.scale.ordinal().range(newColors);
+            } else if (brewerOrdinal.indexOf(id) > 0) {
+                var largestPalette = 12;
+                while (largestPalette > 0) {
+                    if (colorbrewer[id][largestPalette]) {
+                        scale = d3.scale.ordinal().range(colorbrewer[id][largestPalette]);
+                        break;
+                    }
+                    --largestPalette;
+                }
+            }
+            if (!scale) {
+                //  Default to Category20  ---
+                scale = d3.scale.category20();
+            }
+            colors = scale.range();
+        }
+        function ordinal(_) {
+            return scale(_);
+        }
+        ordinal.id = function (_) {
+            if (!arguments.length) return id;
+            id = _;
+            return ordinal;
+        }
+        ordinal.colors = function (_) {
+            if (!arguments.length) return colors;
+            colors = _;
+            return ordinal;
+        }
+        ordinal.clone = function (newID) {
+            ordinalCache[newID] = palette_ordinal(newID, this.color());
+        }
+        ordinal.switch = function (_id, _colors) {
+            if (id === _id) {
+                return this;
+            }
+            return arguments.length ? fetchOrdinalItem(_id, _colors) : fetchOrdinalItem();
+        };
+
+        return ordinal;
+    };
+
+    var rainbowCache = {};
+    function fetchRainbowItem(id, colors, steps) {
+        if (!id) return palette_rainbow();
+        var retVal = rainbowCache[id];
+        if (!retVal) {
+            retVal = palette_rainbow(id, colors);
+            rainbowCache[id] = retVal;
+        }
+        return retVal;
+    };
+
+    function palette_rainbow(id, _colors, _steps) {
         if (!arguments.length) {
-            var retVal = [];
-            for(var key in colorbrewer) {
-                if (sets.indexOf(key) === -1) {
+            var retVal = ["default"];
+            for (var key in colorbrewer) {
+                if (brewerOrdinal.indexOf(key) === -1) {
                     retVal.push(key);
                 }
             }
             return retVal;
         };
-        if (!colorbrewer[palette]) {
-            throw "Invalid color palette:  " + palette;
-        }
-        var largestPalette = 12;
-        while (largestPalette > 0) {
-            if (colorbrewer[palette][largestPalette]) {
-                return custom(colorbrewer[palette][largestPalette], from, to);
-            }
-            --largestPalette;
-        }
-        return null;
-    };
 
-    custom = function (colorArr, from, to, steps) {
-        steps = steps || 32;
-        var subPaletteSize = Math.ceil(steps / (colorArr.length - 1));
-        var range = [];
-        var prevColor = null;
-        colorArr.forEach(function(color) {
-            if (prevColor) {
-                var scale = d3.scale.linear()
-                    .domain([0, subPaletteSize])
-                    .range([prevColor, color])
-                    .interpolate(d3.interpolateLab)
-                ;
-                for(var i = 0; i < subPaletteSize; ++i) {
-                    range.push(scale(i));
+        var id = id;
+        var scale = null;
+        var colors = _colors;
+
+        _custom = function (colors, steps) {
+            steps = steps || 32;
+            var subPaletteSize = Math.ceil(steps / (colors.length - 1));
+            var range = [];
+            var prevColor = null;
+            colors.forEach(function (color) {
+                if (prevColor) {
+                    var scale = d3.scale.linear()
+                        .domain([0, subPaletteSize])
+                        .range([prevColor, color])
+                        .interpolate(d3.interpolateLab)
+                    ;
+                    for (var i = 0; i < subPaletteSize; ++i) {
+                        range.push(scale(i));
+                    }
+                }
+                prevColor = color;
+            });
+            scale = d3.scale.quantize().domain([0, 100]).range(range);
+            return scale;
+        };
+
+        if (_colors) {
+            scale = _custom(_colors, _steps);
+        } else {
+            if (colorbrewer[id]) {
+                var largestPalette = 12;
+                while (largestPalette > 0) {
+                    if (colorbrewer[id][largestPalette]) {
+                        scale = _custom(colorbrewer[id][largestPalette]);
+                        break;
+                    }
+                    --largestPalette;
                 }
             }
-            prevColor = color;
-        });
-        return d3.scale.quantize().domain([from, to]).range(range);
+            if (!scale) {
+                scale = _custom(colorbrewer.RdYlGn[11]);
+            }
+            colors = scale.range();
+
+        }
+        function rainbow(x, low, high) {
+            return scale.domain([low, high])(x);
+        };
+        rainbow.id = function (_) {
+            if (!arguments.length) return id;
+            id = _;
+            return rainbow;
+        };
+        rainbow.colors = function (_) {
+            if (!arguments.length) return colors;
+            colors = _;
+            return rainbow;
+        };
+        rainbow.clone = function (newID) {
+            rainbowCache[newID] = palette_rainbow(newID, this.color());
+        };
+        rainbow.switch = function (_id, _colors) {
+            if (id === _id) {
+                return this;
+            }
+            return arguments.length ? fetchRainbowItem(_id, _colors) : fetchRainbowItem();
+        };
+
+        return rainbow;
     };
-    
+
     test = function(ordinalDivID, brewerDivID, customDivID, customArr, steps) {
         d3.select(ordinalDivID)
           .selectAll(".palette")
-            .data(ordinal(), function(d){ return d; })
+            .data(palette_ordinal(), function (d) { return d; })
           .enter().append("span")
             .attr("class", "palette")
             .attr("title", function(d) { return d; })
             .on("click", function(d) { 
                 console.log(d3.values(d.value).map(JSON.stringify).join("\n")); 
             })
-          .selectAll(".swatch").data(function(d) { return ordinal(d).range(); })
+          .selectAll(".swatch").data(function (d) { return palette_ordinal(d).colors(); })
           .enter().append("span")
             .attr("class", "swatch")
             .style("background-color", function(d) { return d; });
 
         d3.select(brewerDivID)
           .selectAll(".palette")
-            .data(brewer(), function(d){ return d; })
+            .data(palette_rainbow(), function (d) { return d; })
           .enter().append("span")
             .attr("class", "palette")
             .attr("title", function(d) { return d; })
             .on("click", function(d) { 
                 console.log(d3.values(d.value).map(JSON.stringify).join("\n")); 
             })
-          .selectAll(".swatch2").data(function(d) { return brewer(d).range(); })
+          .selectAll(".swatch2").data(function (d) { return palette_rainbow(d).colors(); })
           .enter().append("span")
             .attr("class", "swatch2")
             .style("height", (256 / 32)+"px")
             .style("background-color", function(d) { return d; });
             
-        var scale = {id:customArr.join("_") + steps, scale: custom(customArr, 0, 255, steps)};
+        var palette = { id: customArr.join("_") + steps, scale: palette_rainbow("custom", customArr, steps) };
         d3.select(customDivID)
           .selectAll(".palette")
-            .data([scale], function(d) {return d.id;})
+            .data([palette], function (d) { return d.id; })
           .enter().append("span")
             .attr("class", "palette")
             .attr("title", function(d) { return "aaa";/*d.from + "->" + d.to;*/ })
@@ -111,10 +231,10 @@
                 console.log(d3.values(d.value).map(JSON.stringify).join("\n")); 
             })
           .selectAll(".swatch2").data(function(d) {
-                var domain = d.scale.domain();
                 var retVal = [];
-                for (var i = domain[0]; i <= domain[1]; ++i) 
-                  retVal.push(d.scale(i));
+                for (var i = 0; i <= 255; ++i) {
+                    retVal.push(palette.scale(i, 0, 255));
+                }
                 return retVal;
           })
           .enter().append("span")
@@ -123,9 +243,8 @@
     };    
 
     return {
-        ordinal: ordinal,
-        brewer: brewer,
-        custom: custom,
-        test: test        
+        ordinal: fetchOrdinalItem,
+        rainbow: fetchRainbowItem,
+        test: test
     };
 }));

--- a/widgets/src/common/SVGWidget.js
+++ b/widgets/src/common/SVGWidget.js
@@ -316,7 +316,6 @@
             element = element || this._element;
             element.selectAll("path[fixme-start],path[fixme-end]")
                 .attr("marker-start", function (d) {
-                    var x = this.getAttribute("fixme-start");
                     return this.getAttribute("fixme-start");
                 })
                 .attr("marker-end", function (d) { return this.getAttribute("fixme-end"); })

--- a/widgets/src/common/Widget.js
+++ b/widgets/src/common/Widget.js
@@ -36,7 +36,7 @@
         return null;
     })();
     Widget.prototype.isIE = Widget.prototype.ieVersion !== null;
-    Widget.prototype.svgMarkerGlitch = Widget.prototype.isIE && Widget.prototype.ieVersion <= 11;
+    Widget.prototype.svgMarkerGlitch = Widget.prototype.isIE && Widget.prototype.ieVersion <= 12;
     Widget.prototype.MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver || function (callback) {
         //  Just enough for HTMLOverlay and C3  ---
         this.callback = callback;
@@ -132,7 +132,7 @@
             switch (type) {
                 case "set":
                     if (!options || options.indexOf(_) < 0) {
-                        throw "Invalid value for '" + id + "':  " + _;
+                        console.log("Invalid value for '" + id + "':  " + _);
                     }
                     break;
                 case "boolean":

--- a/widgets/src/google/Bar.js
+++ b/widgets/src/google/Bar.js
@@ -1,18 +1,16 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "./Common", "../common/Palette"], factory);
+        define(["d3/d3", "./Common"], factory);
     } else {
-        root.Bar = factory(root.d3, root.Common, root.Palette);
+        root.Bar = factory(root.d3, root.Common);
     }
-}(this, function (d3, Common, Palette) {
+}(this, function (d3, Common) {
 
     function Bar(tget) {
         Common.call(this);
         this._class = "google_Bar";
     };
     Bar.prototype = Object.create(Common.prototype);
-
-    Bar.prototype.d3Color = Palette.ordinal("category20");
 
     Bar.prototype.enter = function (domNode, element) {
         var context = this;
@@ -31,7 +29,7 @@
         var context = this;
 
         var colors = this._columns.filter(function (d, i) { return i > 0;}).map(function (row) {
-            return this.d3Color(row);
+            return this._palette(row);
         }, this);
 
         var chartOptions = {

--- a/widgets/src/google/Column.js
+++ b/widgets/src/google/Column.js
@@ -1,19 +1,17 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "./Common", "../common/Palette"], factory);
+        define(["d3/d3", "./Common"], factory);
     } else {
-        root.Column = factory(root.d3, root.Common, root.Palette);
+        root.Column = factory(root.d3, root.Common);
     }
-}(this, function (d3, Common, Palette) {
+}(this, function (d3, Common) {
 
     function Column() {
         Common.call(this);
         this._class = "google_Column";
     };
     Column.prototype = Object.create(Common.prototype);
-
-    Column.prototype.d3Color = Palette.ordinal("category20");
-
+    
     Column.prototype.enter = function (domNode, element) {
         var context = this;
 
@@ -31,7 +29,7 @@
         var context = this;
 
         var colors = this._columns.filter(function (d, i) { return i > 0; }).map(function (row) {
-            return this.d3Color(row);
+            return this._palette(row);
         }, this);
 
         var chartOptions = {

--- a/widgets/src/google/Line.js
+++ b/widgets/src/google/Line.js
@@ -1,10 +1,10 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "./Common", "../common/Palette"], factory);
+        define(["d3/d3", "./Common"], factory);
     } else {
-        root.Line = factory(root.d3, root.Common, root.Palette);
+        root.Line = factory(root.d3, root.Common);
     }
-}(this, function (d3, Common, Palette) {
+}(this, function (d3, Common) {
 
     function Line(tget) {
         Common.call(this);
@@ -13,8 +13,6 @@
         this.data([]);
     };
     Line.prototype = Object.create(Common.prototype);
-
-    Line.prototype.d3Color = Palette.ordinal("category20");
 
     Line.prototype.enter = function (domNode, element) {
         var context = this;
@@ -33,7 +31,7 @@
         var context = this;
 
         var colors = this._columns.filter(function (d, i) { return i > 0; }).map(function (row) {
-            return this.d3Color(row);
+            return this._palette(row);
         }, this);
 
         var chartOptions = {

--- a/widgets/src/google/Pie.js
+++ b/widgets/src/google/Pie.js
@@ -1,10 +1,10 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "./Common", "../common/Palette"], factory);
+        define(["d3/d3", "./Common"], factory);
     } else {
-        root.Pie = factory(root.d3, root.Common, root.Palette);
+        root.Pie = factory(root.d3, root.Common);
     }
-}(this, function (d3, Common, Palette) {
+}(this, function (d3, Common) {
 
     function Pie(tget) {
         Common.call(this);
@@ -13,8 +13,6 @@
         this._is3D = true;
     };
     Pie.prototype = Object.create(Common.prototype);
-
-    Pie.prototype.d3Color = Palette.ordinal("category20");
 
     Pie.prototype.is3D = function (_) {
         if (!arguments.length) return this._is3D;
@@ -40,7 +38,7 @@
         var context = this;
 
         var colors = this._data.map(function (row) {
-            return this.d3Color(row[0]);
+            return this._palette(row[0]);
         }, this);
 
         var chartOptions = {

--- a/widgets/src/map/Choropleth.js
+++ b/widgets/src/map/Choropleth.js
@@ -1,10 +1,10 @@
 ﻿(function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "../common/SVGWidget", "./IChoropleth", "../common/Palette", "css!./Choropleth"], factory);
+        define(["d3/d3", "../common/SVGWidget", "./IChoropleth", "css!./Choropleth"], factory);
     } else {
-        root.Choropleth = factory(root.d3, root.SVGWidget, root.IChoropleth, root.Palette);
+        root.Choropleth = factory(root.d3, root.SVGWidget, root.IChoropleth);
     }
-}(this, function (d3, SVGWidget, IChoropleth, Palette) {
+}(this, function (d3, SVGWidget, IChoropleth) {
     function Choropleth() {
         SVGWidget.call(this);
         IChoropleth.call(this);
@@ -13,12 +13,12 @@
         this._dataMap = {};
         this._dataMinWeight = 0;
         this._dataMaxWeight = 0;
-        this._palette = "YlOrRd";
 
         this.active = d3.select(null);
     };
     Choropleth.prototype = Object.create(SVGWidget.prototype);
     Choropleth.prototype.implements(IChoropleth.prototype);
+    Choropleth.prototype.publish("paletteID", "YlOrRd", "set", "Palette ID", Choropleth.prototype._palette.switch());
 
     Choropleth.prototype.data = function (_) {
         var retVal = SVGWidget.prototype.data.apply(this, arguments);
@@ -58,12 +58,6 @@
             ;
         }
         return retVal;
-    }
-
-    Choropleth.prototype.palette = function (_) {
-        if (!arguments.length) return this._palette;
-        this._palette = _;
-        return this;
     }
 
     Choropleth.prototype.projection = function (_) {
@@ -132,9 +126,7 @@
     };
 
     Choropleth.prototype.update = function (domNode, element) {
-        var context = this;
-
-        this.d3Color = Palette.brewer(this._palette, this._dataMinWeight, this._dataMaxWeight);
+        this._palette = this._palette.switch(this._paletteID);
     };
 
     // A modified d3.geo.albersUsa to include Puerto Rico.

--- a/widgets/src/map/ChoroplethCounties.js
+++ b/widgets/src/map/ChoroplethCounties.js
@@ -7,6 +7,7 @@
 }(this, function (d3, Choropleth, topojson, usCounties) {
     function ChoroplethCounties() {
         Choropleth.call(this);
+        this._class = "map_ChoroplethCounties";
 
         this.projection("albersUsaPr");
     };
@@ -14,6 +15,8 @@
 
     ChoroplethCounties.prototype.enter = function (domNode, element) {
         Choropleth.prototype.enter.apply(this, arguments);
+        element.classed("map_Choropleth", true);
+
         var choroPaths = this._svg.selectAll("path").data(topojson.feature(usCounties.topology, usCounties.topology.objects.counties).features)
 
         //  Enter  ---
@@ -35,6 +38,7 @@
 
     ChoroplethCounties.prototype.update = function (domNode, element) {
         Choropleth.prototype.update.apply(this, arguments);
+
         //console.time("ChoroplethCounties.prototype.update");
         var context = this;
         //  Update  ---
@@ -43,7 +47,7 @@
             .each(function (d) {
                 var weight = context._dataMap[d.id] ? context._dataMap[d.id][1] : undefined;
                 d3.select(this)
-                    .style("fill", weight === undefined ? "url(#hash)" : context.d3Color(weight))
+                    .style("fill", weight === undefined ? "url(#hash)" : context._palette(weight, context._dataMinWeight, context._dataMaxWeight))
                     .select("title")
                     .text(usCounties.countyNames[d.id] + (weight === undefined ? "" : " (" + weight + ")"))
                 ;

--- a/widgets/src/map/ChoroplethCountries.js
+++ b/widgets/src/map/ChoroplethCountries.js
@@ -7,6 +7,7 @@
 }(this, function (d3, Choropleth, topojson, countries, usStates) {
     function ChoroplethCounties() {
         Choropleth.call(this);
+        this._class = "map_ChoroplethCountries";
 
         this._dataMap = {};
         this._dataMaxWeight = 0;
@@ -41,8 +42,9 @@
     };
 
     ChoroplethCounties.prototype.enter = function (domNode, element) {
-        var context = this;
         Choropleth.prototype.enter.apply(this, arguments);
+        element.classed("map_Choropleth", true);    
+
         this.lookup = {};
         var stateArray = topojson.feature(usStates.topology, usStates.topology.objects.states).features.map(function (item) {
             item.category = "State";
@@ -93,7 +95,7 @@
                 if (weight === undefined) {
                     return "url(#hash)";
                 }
-                return context.d3Color(context._dataMap[code]);
+                return context._palette(weight, context._dataMinWeight, context._dataMaxWeight);
             })
         ;
 

--- a/widgets/src/map/ChoroplethStates.js
+++ b/widgets/src/map/ChoroplethStates.js
@@ -7,6 +7,7 @@
 }(this, function (d3, Choropleth, topojson, usStates) {
     function ChoroplethStates() {
         Choropleth.call(this);
+        this._class = "map_ChoroplethStates";
 
         this.projection("albersUsaPr");
     };
@@ -14,6 +15,8 @@
 
     ChoroplethStates.prototype.enter = function (domNode, element) {
         Choropleth.prototype.enter.apply(this, arguments);
+        element.classed("map_Choropleth", true);
+
         var choroPaths = this._svg.selectAll("path").data(topojson.feature(usStates.topology, usStates.topology.objects.states).features)
 
         //  Enter  ---
@@ -45,7 +48,7 @@
                 var code = usStates.stateNames[d.id].code;
                 var weight = context._dataMap[code] ? context._dataMap[code][1] : undefined;
                 d3.select(this)
-                    .style("fill", weight === undefined ? "url(#hash)" : context.d3Color(weight))
+                    .style("fill", weight === undefined ? "url(#hash)" : context._palette(weight, context._dataMinWeight, context._dataMaxWeight))
                     .select("title")
                     .text(usStates.stateNames[d.id].name + (weight === undefined ? "" : " (" + weight + ")"))
                 ;

--- a/widgets/src/map/IChoropleth.js
+++ b/widgets/src/map/IChoropleth.js
@@ -1,14 +1,15 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["./us-states"], factory);
+        define(["../common/Palette", "./us-states"], factory);
     } else {
-        root.IChoropleth = factory(root.usStates);
+        root.IChoropleth = factory(root.Palette, root.usStates);
     }
-}(this, function (usStates) {
+}(this, function (Palette, usStates) {
     function IChoropleth() {
     };
-    
-    IChoropleth.prototype.testStateData = function() {
+    IChoropleth.prototype._palette = Palette.rainbow("default");
+
+    IChoropleth.prototype.testData = function() {
         var nameCodeMap = {};
         for (var key in usStates.stateNames) {
             var item = usStates.stateNames[key];

--- a/widgets/src/marshaller/Graph.js
+++ b/widgets/src/marshaller/Graph.js
@@ -71,11 +71,11 @@
                             switch (item.type) {
                                 case "CHORO":
                                     newSurface._menu
-                                        .data(Palette.brewer())
+                                        .data(Palette.rainbow())
                                     ;
                                     newSurface._menu.click = function (d) {
                                         newSurface._content
-                                            .palette(d)
+                                            .paletteID(d)
                                             .render(d)
                                         ;
                                     }

--- a/widgets/src/other/Comms.js
+++ b/widgets/src/other/Comms.js
@@ -106,20 +106,21 @@
         var mapping = this._mappings[resultName];
         if (mapping) {
             response[resultName] = response[resultName].map(function (item) {
-                var row = {};
+                var row = [];
                 if (mapping.x && mapping.x instanceof Array) {
                     //  LINE Mapping  ---
                     row = [];
                     for (var i = 0; i < mapping.x.length; ++i) {
-                        row.push({
-                            label: item[mapping.x[i]],
-                            weight: item[mapping.y[i]]
-                        })
+                        row.push(item[mapping.y[i]]);
                     }
                 } else {
                     //  Regular Mapping  ---
                     for (var key in mapping) {
-                        row[mapping[key]] = item[key];
+                        if (mapping[key] === "label") {
+                            row[0] = item[key];
+                        } else if (mapping[key] === "weight") {
+                            row[1] = item[key];
+                        }
                     }
                 }
                 return row;

--- a/widgets/src/tree/CirclePacking.js
+++ b/widgets/src/tree/CirclePacking.js
@@ -1,10 +1,10 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "../common/SVGWidget", "../common/Palette", "./ITree", "../common/Text", "../common/FAChar", "css!./CirclePacking"], factory);
+        define(["d3/d3", "../common/SVGWidget", "./ITree", "../common/Text", "../common/FAChar", "css!./CirclePacking"], factory);
     } else {
-        root.CirclePacking = factory(root.d3, root.SVGWidget, root.Palette, root.ITree, root.Text, root.FAChar);
+        root.CirclePacking = factory(root.d3, root.SVGWidget, root.ITree, root.Text, root.FAChar);
     }
-}(this, function (d3, SVGWidget, Palette, ITree, Text, FAChar) {
+}(this, function (d3, SVGWidget, ITree, Text, FAChar) {
     function CirclePacking(target) {
         SVGWidget.call(this);
         ITree.call(this);
@@ -44,6 +44,7 @@
             .data(nodes)
           .enter().append("circle")
             .attr("class", function (d) { return d.parent ? d.children ? "node" : "node leaf" : "node root"; })
+            .style("fill", function (d) { return context._palette(d.label); })
             .on("click", function (d) { if (focus !== d) context.zoom(d), d3.event.stopPropagation(); })
         ;
 

--- a/widgets/src/tree/Dendrogram.js
+++ b/widgets/src/tree/Dendrogram.js
@@ -54,8 +54,10 @@
         var node = nodes.enter().append("g")
             .attr("class", "node")
         ;
+        var context = this;
         node.append("circle")
             .attr("r", 4.5)
+            .style("fill", function (d) { return context._palette(d.label); })
         ;
         node.append("text")
             .attr("dx", function (d) { return d.children ? -8 : 8; })

--- a/widgets/src/tree/ITree.js
+++ b/widgets/src/tree/ITree.js
@@ -1,12 +1,14 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define([], factory);
+        define(["../common/Palette"], factory);
     } else {
-        root.ITree = factory();
+        root.ITree = factory(root.Palette);
     }
-}(this, function () {
+}(this, function (Palette) {
     function ITree() {
     };
+
+    ITree.prototype._palette = Palette.ordinal("default");
 
     //  Data ---
     ITree.prototype.testData = function () {
@@ -37,8 +39,6 @@
         this.data(data);
         return this;
     };
-
-    //  Properties  ---
 
     //  Events  ---
     ITree.prototype.click = function (d) {

--- a/widgets/src/tree/SunburstPartition.js
+++ b/widgets/src/tree/SunburstPartition.js
@@ -1,10 +1,10 @@
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3/d3", "../common/SVGWidget", "../common/Palette", "./ITree", "../common/Text", "../common/FAChar", "css!./SunburstPartition"], factory);
+        define(["d3/d3", "../common/SVGWidget", "./ITree", "../common/Text", "../common/FAChar", "css!./SunburstPartition"], factory);
     } else {
-        root.SunburstPartition = factory(root.d3, root.SVGWidget, root.Palette, root.ITree, root.Text, root.FAChar);
+        root.SunburstPartition = factory(root.d3, root.SVGWidget, root.ITree, root.Text, root.FAChar);
     }
-}(this, function (d3, SVGWidget, Palette, ITree, Text, FAChar) {
+}(this, function (d3, SVGWidget, ITree, Text, FAChar) {
     function SunburstPartition(target) {
         SVGWidget.call(this);
         ITree.call(this);
@@ -12,8 +12,6 @@
     };
     SunburstPartition.prototype = Object.create(SVGWidget.prototype);
     SunburstPartition.prototype.implements(ITree.prototype);
-
-    SunburstPartition.prototype.d3Color = Palette.ordinal("category20");
 
     SunburstPartition.prototype.enter = function (domNode, element) {
         var context = this;
@@ -49,7 +47,7 @@
             .data(this.partition.nodes(this._data))
             .enter().append("path")
             .attr("d", this.arc)
-            .style("fill", function (d) { return d.__viz_fill ? d.__viz_fill : context.d3Color(d.label); })
+            .style("fill", function (d) { return d.__viz_fill ? d.__viz_fill : context._palette(d.label); })
             .style("stroke", function (d) {
                 return d.value > 16 ? "white" : "none";
             })


### PR DESCRIPTION
Re-factor palette to two global singletons:
* Ordinal
* Rainbow

Put google examples into their own code section (for working offline)
Add gauge example.

Update comms mappings to support new format.

Fix IE arrows for IE <= 12

Enable mouse click for MultiChartSurface.

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>

Fixes #192