### PR TITLE
URL Params should be URI decoded before being used.

### DIFF
--- a/widgets/src/other/Comms.js
+++ b/widgets/src/other/Comms.js
@@ -26,7 +26,7 @@
             tmp = tmp.split("&");
             tmp.map(function (item) {
                 var tmpItem = item.split("=");
-                params[tmpItem[0]] = tmpItem[1];
+                params[decodeURIComponent(tmpItem[0])] = decodeURIComponent(tmpItem[1]);
             });
         }
         this._protocol = parser.protocol;


### PR DESCRIPTION
Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>