### PR TITLE
Limit scope of onSelect updates.

### DIFF
--- a/demos/dashboard/app/tpl/Main.html
+++ b/demos/dashboard/app/tpl/Main.html
@@ -37,8 +37,9 @@
                                     <input id="${id}Url" class="form-control" name="search" placeholder="HIPIE URL" autocomplete="off" autofocus="autofocus" type="text" value="http://10.239.227.24:8010/WsWorkunits/WUResult?Wuid=W20141125-091046&ResultName=Ins002_DDL">
                                     <input id="${id}Url" class="form-control" name="search" placeholder="HIPIE URL" autocomplete="off" autofocus="autofocus" type="text" value="http://10.173.147.1:8002/WsEcl/submit/query/roxie/drealeed_testaddressclean.ins002_service/json">
                                     <input id="${id}Url" class="form-control" name="search" placeholder="HIPIE URL" autocomplete="off" autofocus="autofocus" type="text" value="http://10.239.227.24:8002/WsEcl/submit/query/roxie/hipie_testrelavatorsmall1.ins002_service/json">
+                                    <input id="${id}Url" class="form-control" name="search" placeholder="HIPIE URL" autocomplete="off" autofocus="autofocus" type="text" value="http://10.173.147.1:8010/WsWorkunits/WUResult?Wuid=W20150416-204730&ResultName=leeddx_Interactivity2_Comp_Ins003_DDL">
                                     -->
-                                    <input id="${id}Url" class="form-control" name="search" placeholder="HIPIE URL" autocomplete="off" autofocus="autofocus" type="text" value="http://10.239.227.24:8010/WsWorkunits/WUResult?Wuid=W20150210-173407&ResultName=leeddx_TestServiceViz_Comp_Ins001_DDL">
+                                    <input id="${id}Url" class="form-control" name="search" placeholder="HIPIE URL" autocomplete="off" autofocus="autofocus" type="text" value="http://10.173.147.1:8010/WsWorkunits/WUResult?Wuid=W20150416-204730&ResultName=leeddx_Interactivity2_Comp_Ins003_DDL">
                                     <span class="input-group-addon" data-dojo-attach-event="onClick:_onGo"><span class="glyphicon glyphicon-arrow-right"></span></span>
                                 </div>
                             </div>


### PR DESCRIPTION
If a datasource update has been triggered by a onSelect event, then the list
of visualizations that are updated by the new data is limited to the list of
visualizations that the onSelect specifies.

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>