### PR TITLE
Fix widget prefix for non-AMD usage

### DIFF
--- a/src/amchart/Area.js
+++ b/src/amchart/Area.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonSerial", "amcharts.serial", "../api/INDChart", "css!./Area"], factory);
     } else {
-        root.amcharts_Area = factory(root.d3, root.amcharts_CommonSerial, root.amcharts, root.api_INDChart);
+        root.amchart_Area = factory(root.d3, root.amchart_CommonSerial, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonSerial, AmCharts, INDChart) {
     function Area() {
         CommonSerial.call(this);
-        this._class = "amcharts_Area";
+        this._class = "amchart_Area";
         this._tag = "div";
        
         this._gType = "line";

--- a/src/amchart/Bar.js
+++ b/src/amchart/Bar.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonSerial", "amcharts.serial", "../api/INDChart", "css!./Bar"], factory);
     } else {
-        root.amcharts_Bar = factory(root.d3, root.amcharts_CommonSerial, root.amcharts, root.api_INDChart);
+        root.amchart_Bar = factory(root.d3, root.amchart_CommonSerial, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonSerial, AmCharts, INDChart) {
     function Bar() {
         CommonSerial.call(this);
-        this._class = "amcharts_Bar";
+        this._class = "amchart_Bar";
         this._tag = "div";
         
         this._gType = "column";

--- a/src/amchart/Bubble.js
+++ b/src/amchart/Bubble.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonXY", "amcharts.xy", "../api/INDChart", "css!./Bar"], factory);
     } else {
-        root.amcharts_Bubble = factory(root.d3, root.amcharts_CommonXY, root.amcharts, root.api_INDChart);
+        root.amchart_Bubble = factory(root.d3, root.amchart_CommonXY, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonXY, AmCharts, INDChart) {
     function Bubble() {
         CommonXY.call(this);
-        this._class = "amcharts_Bubble";
+        this._class = "amchart_Bubble";
         this._tag = "div";
         
         this._type = "Bubble";

--- a/src/amchart/Candle.js
+++ b/src/amchart/Candle.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonSerial", "amcharts.serial", "../api/INDChart"], factory);
     } else {
-        root.amcharts_Candle = factory(root.d3, root.amcharts_CommonSerial, root.amcharts, root.api_INDChart);
+        root.amchart_Candle = factory(root.d3, root.amchart_CommonSerial, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonSerial, AmCharts, INDChart) {
     function Candle() {
         CommonSerial.call(this);
-        this._class = "amcharts_Candle";
+        this._class = "amchart_Candle";
         this._tag = "div";
         
         this._gType = "candlestick";

--- a/src/amchart/CommonFunnel.js
+++ b/src/amchart/CommonFunnel.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/HTMLWidget", "amcharts.funnel"], factory);
     } else {
-        root.amcharts_CommonFunnel = factory(root.d3, root.common_HTMLWidget, root.amcharts);
+        root.amchart_CommonFunnel = factory(root.d3, root.common_HTMLWidget, root.amcharts);
     }
 
 }(this, function(d3, HTMLWidget, AmCharts) {

--- a/src/amchart/CommonRadar.js
+++ b/src/amchart/CommonRadar.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/HTMLWidget", "amcharts.radar"], factory);
     } else {
-        root.amcharts_CommonRadar = factory(root.d3, root.common_HTMLWidget, root.amcharts);
+        root.amchart_CommonRadar = factory(root.d3, root.common_HTMLWidget, root.amcharts);
     }
 
 }(this, function(d3, HTMLWidget, AmCharts) {

--- a/src/amchart/CommonSerial.js
+++ b/src/amchart/CommonSerial.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/HTMLWidget", "amcharts.serial"], factory);
     } else {
-        root.amcharts_CommonSerial = factory(root.d3, root.common_HTMLWidget, root.amcharts);
+        root.amchart_CommonSerial = factory(root.d3, root.common_HTMLWidget, root.amcharts);
     }
 
 }(this, function(d3, HTMLWidget, AmCharts) {

--- a/src/amchart/CommonXY.js
+++ b/src/amchart/CommonXY.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/HTMLWidget", "amcharts.xy"], factory);
     } else {
-        root.amcharts_CommonXY = factory(root.d3, root.common_HTMLWidget, root.amcharts);
+        root.amchart_CommonXY = factory(root.d3, root.common_HTMLWidget, root.amcharts);
     }
 }(this, function(d3, HTMLWidget, AmCharts) {
     function CommonXY() {

--- a/src/amchart/FloatingColumn.js
+++ b/src/amchart/FloatingColumn.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonSerial", "amcharts.serial", "../api/INDChart"], factory);
     } else {
-        root.amcharts_FloatingColumn = factory(root.d3, root.amcharts_CommonSerial, root.amcharts, root.api_INDChart);
+        root.amchart_FloatingColumn = factory(root.d3, root.amchart_CommonSerial, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonSerial, AmCharts, INDChart) {
     function FloatingColumn() {
         CommonSerial.call(this);
-        this._class = "amcharts_FloatingColumn";
+        this._class = "amchart_FloatingColumn";
         this._tag = "div";
         
         this._gType = "column";

--- a/src/amchart/Funnel.js
+++ b/src/amchart/Funnel.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonFunnel", "amcharts.funnel", "../api/I2DChart"], factory);
     } else {
-        root.amcharts_Funnel = factory(root.d3, root.common_HTMLWidget, root.amcharts, root.api_I2DChart);
+        root.amchart_Funnel = factory(root.d3, root.common_HTMLWidget, root.amcharts, root.api_I2DChart);
     }
 }(this, function(d3, CommonFunnel, AmCharts, I2DChart) {
     function Funnel() {
         CommonFunnel.call(this);
-        this._class = "amcharts_Funnel";
+        this._class = "amchart_Funnel";
     };
     
     Funnel.prototype = Object.create(CommonFunnel.prototype);

--- a/src/amchart/Gauge.js
+++ b/src/amchart/Gauge.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/HTMLWidget", "amcharts.gauge", "../api/I1DChart"], factory);
     } else {
-        root.amcharts_Gauge = factory(root.d3, root.common_HTMLWidget, root.amcharts, root.api_I1DChart);
+        root.amchart_Gauge = factory(root.d3, root.common_HTMLWidget, root.amcharts, root.api_I1DChart);
     }
 }(this, function(d3, HTMLWidget, AmCharts, I1DChart) {
     function Gauge() {
         HTMLWidget.call(this);
-        this._class = "amcharts_Gauge";
+        this._class = "amchart_Gauge";
         this._tag = "div";
 
         this._chart = {};

--- a/src/amchart/Line.js
+++ b/src/amchart/Line.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonSerial", "amcharts.serial", "../api/INDChart"], factory);
     } else {
-        root.amcharts_Line = factory(root.d3, root.amcharts_CommonSerial, root.amcharts, root.api_INDChart);
+        root.amchart_Line = factory(root.d3, root.amchart_CommonSerial, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonSerial, AmCharts, INDChart) {
     function Line() {
         CommonSerial.call(this);
-        this._class = "amcharts_Line";
+        this._class = "amchart_Line";
         this._tag = "div";
         
         this._gType = "smoothedLine";

--- a/src/amchart/Pie.js
+++ b/src/amchart/Pie.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/HTMLWidget", "amcharts.pie", "../api/I2DChart"], factory);
     } else {
-        root.amcharts_Pie = factory(root.d3, root.common_HTMLWidget, root.amcharts, root.api_I2DChart);
+        root.amchart_Pie = factory(root.d3, root.common_HTMLWidget, root.amcharts, root.api_I2DChart);
     }
 }(this, function(d3, HTMLWidget, AmCharts, I2DChart) {
     function Pie() {
         HTMLWidget.call(this);
-        this._class = "amcharts_Pie";
+        this._class = "amchart_Pie";
         this._tag = "div";
 
         this._chart = {};

--- a/src/amchart/Polar.js
+++ b/src/amchart/Polar.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonRadar", "amcharts.radar", "../api/INDChart"], factory);
     } else {
-        root.amcharts_Polar = factory(root.d3, root.amcharts_CommonRadar, root.amcharts, root.api_INDChart);
+        root.amchart_Polar = factory(root.d3, root.amchart_CommonRadar, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonRadar, AmCharts, INDChart) {
     function Polar() {
         CommonRadar.call(this);
-        this._class = "amcharts_Polar";
+        this._class = "amchart_Polar";
         this._tag = "div";
         this._gType = "column";
     };

--- a/src/amchart/Pyramid.js
+++ b/src/amchart/Pyramid.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonFunnel", "amcharts.funnel", "../api/I2DChart"], factory);
     } else {
-        root.amcharts_Pyramid = factory(root.d3, root.amcharts_CommonFunnel, root.amcharts, root.api_I2DChart);
+        root.amchart_Pyramid = factory(root.d3, root.amchart_CommonFunnel, root.amcharts, root.api_I2DChart);
     }
 }(this, function(d3, CommonFunnel, AmCharts, I2DChart) {
     function Pyramid() {
         CommonFunnel.call(this);
-        this._class = "amcharts_Pyramid";
+        this._class = "amchart_Pyramid";
         this._tag = "div";
     };
     

--- a/src/amchart/Scatter.js
+++ b/src/amchart/Scatter.js
@@ -3,12 +3,12 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./CommonXY", "amcharts.xy", "../api/INDChart", "css!./Bar"], factory);
     } else {
-        root.amcharts_Scatter = factory(root.d3, root.amcharts_CommonXY, root.amcharts, root.api_INDChart);
+        root.amchart_Scatter = factory(root.d3, root.amchart_CommonXY, root.amcharts, root.api_INDChart);
     }
 }(this, function(d3, CommonXY, AmCharts, INDChart) {
     function Scatter() {
         CommonXY.call(this);
-        this._class = "amcharts_Scatter";
+        this._class = "amchart_Scatter";
         this._tag = "div";
         
         this._type = "Scatter";

--- a/src/api/I1DChart.js
+++ b/src/api/I1DChart.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["../common/Palette"], factory);
     } else {
-        root.chart_I1DChart = factory(root.common_Palette);
+        root.api_I1DChart = factory(root.common_Palette);
     }
 }(this, function (Palette) {
     function I1DChart() {

--- a/src/api/I2DChart.js
+++ b/src/api/I2DChart.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["../common/Palette"], factory);
     } else {
-        root.chart_I2DChart = factory(root.common_Palette);
+        root.api_I2DChart = factory(root.common_Palette);
     }
 }(this, function (Palette) {
     function I2DChart() {

--- a/src/api/IGraph.js
+++ b/src/api/IGraph.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define([], factory);
     } else {
-        root.graph_IGraph = factory();
+        root.api_IGraph = factory();
     }
 }(this, function () {
     function IGraph() {

--- a/src/api/INDChart.js
+++ b/src/api/INDChart.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["../common/Palette"], factory);
     } else {
-        root.chart_INDChart = factory(root.common_Palette);
+        root.api_INDChart = factory(root.common_Palette);
     }
 }(this, function (Palette) {
     function INDChart() {

--- a/src/api/ITree.js
+++ b/src/api/ITree.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["../common/Palette"], factory);
     } else {
-        root.tree_ITree = factory(root.common_Palette);
+        root.api_ITree = factory(root.common_Palette);
     }
 }(this, function (Palette) {
     function ITree() {

--- a/src/c3chart/Common1D.js
+++ b/src/c3chart/Common1D.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["./Common", "../api/I1DChart"], factory);
     } else {
-        root.c3chart_Common1D = factory(root.c3chart_Common, root.chart_I1DChart);
+        root.c3chart_Common1D = factory(root.c3chart_Common, root.api_I1DChart);
     }
 }(this, function (Common, I1DChart) {
     function Common1D(target) {

--- a/src/c3chart/Common2D.js
+++ b/src/c3chart/Common2D.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["./Common", "../api/I2DChart"], factory);
     } else {
-        root.c3chart_Common2D = factory(root.c3chart_Common, root.chart_I2DChart);
+        root.c3chart_Common2D = factory(root.c3chart_Common, root.api_I2DChart);
     }
 }(this, function (Common, I2DChart) {
     function Common2D(target) {

--- a/src/c3chart/CommonND.js
+++ b/src/c3chart/CommonND.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["./Common", "../api/INDChart"], factory);
     } else {
-        root.c3chart_CommonND = factory(root.c3chart_Common, root.chart_INDChart);
+        root.c3chart_CommonND = factory(root.c3chart_Common, root.api_INDChart);
     }
 }(this, function (Common, INDChart) {
     function CommonND(target) {

--- a/src/chart/Bubble.js
+++ b/src/chart/Bubble.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/SVGWidget", "../api/I2DChart", "../common/Text", "../common/FAChar", "css!./Bubble"], factory);
     } else {
-        root.chart_Bubble = factory(root.d3, root.common_SVGWidget, root.chart_I2DChart, root.common_Text, root.common_FAChar);
+        root.chart_Bubble = factory(root.d3, root.common_SVGWidget, root.api_I2DChart, root.common_Text, root.common_FAChar);
     }
 }(this, function (d3, SVGWidget, I2DChart, Text, FAChar) {
     function Bubble(target) {

--- a/src/chart/Column.js
+++ b/src/chart/Column.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./XYAxis", "../api/I2DChart", "css!./Column"], factory);
     } else {
-        root.chart_Column = factory(root.d3, root.chart_XYAxis, root.chart_I2DChart);
+        root.chart_Column = factory(root.d3, root.chart_XYAxis, root.api_I2DChart);
     }
 }(this, function (d3, XYAxis, I2DChart) {
     function Column(target) {

--- a/src/chart/Line.js
+++ b/src/chart/Line.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "./XYAxis", "../api/INDChart", "css!./Line"], factory);
     } else {
-        root.chart_Line = factory(root.d3, root.chart_XYAxis, root.chart_INDChart);
+        root.chart_Line = factory(root.d3, root.chart_XYAxis, root.api_INDChart);
     }
 }(this, function (d3, XYAxis, INDChart) {
     function Line(target) {

--- a/src/chart/MultiChart.js
+++ b/src/chart/MultiChart.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/SVGWidget", "../api/INDChart", "require"], factory);
     } else {
-        root.chart_MultiChart = factory(root.d3, root.common_SVGWidget, root.chart_INDChart, root.require);
+        root.chart_MultiChart = factory(root.d3, root.common_SVGWidget, root.api_INDChart, root.require);
     }
 }(this, function (d3, SVGWidget, INDChart, require) {
     var _2dChartTypes = [

--- a/src/chart/MultiChartSurface.js
+++ b/src/chart/MultiChartSurface.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/ResizeSurface", "./MultiChart", "../api/INDChart"], factory);
     } else {
-        root.chart_MultiChartSurface = factory(root.d3, root.common_ResizeSurface, root.chart_MultiChart, root.chart_INDChart);
+        root.chart_MultiChartSurface = factory(root.d3, root.common_ResizeSurface, root.chart_MultiChart, root.api_INDChart);
     }
 }(this, function (d3, ResizeSurface, MultiChart, INDChart) {
     function MultiChartSurface() {

--- a/src/chart/Pie.js
+++ b/src/chart/Pie.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/SVGWidget", "../api/I2DChart", "../common/Text", "../common/FAChar", "css!./Pie"], factory);
     } else {
-        root.chart_Pie = factory(root.d3, root.common_SVGWidget, root.chart_I2DChart, root.common_Text, root.common_FAChar);
+        root.chart_Pie = factory(root.d3, root.common_SVGWidget, root.api_I2DChart, root.common_Text, root.common_FAChar);
     }
 }(this, function (d3, SVGWidget, I2DChart, Text, FAChar) {
     function Pie(target) {

--- a/src/google/Common2D.js
+++ b/src/google/Common2D.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../google/Common", "../api/I2DChart", "goog!visualization,1,packages:[corechart]"], factory);
     } else {
-        root.google_Common2D = factory(root.d3, root.google_Common, root.chart_I2DChart);
+        root.google_Common2D = factory(root.d3, root.google_Common, root.api_I2DChart);
     }
 }(this, function (d3, Common, I2DChart) {
 

--- a/src/google/CommonND.js
+++ b/src/google/CommonND.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../google/Common", "../api/INDChart", "goog!visualization,1,packages:[corechart]"], factory);
     } else {
-        root.google_CommonND = factory(root.d3, root.google_Common, root.chart_INDChart);
+        root.google_CommonND = factory(root.d3, root.google_Common, root.api_INDChart);
     }
 }(this, function (d3, Common, INDChart) {
 

--- a/src/graph/Graph.js
+++ b/src/graph/Graph.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/SVGWidget", "../api/IGraph", "./Vertex", "./GraphData", "./GraphLayouts", "../other/Bag", "css!./Graph"], factory);
     } else {
-        root.graph_Graph = factory(root.d3, root.common_SVGWidget, root.graph_IGraph, root.graph_Vertex, root.graph_GraphData, root.graph_GraphLayouts, root.other_Bag);
+        root.graph_Graph = factory(root.d3, root.common_SVGWidget, root.api_IGraph, root.graph_Vertex, root.graph_GraphData, root.graph_GraphLayouts, root.other_Bag);
     }
 }(this, function (d3, SVGWidget, IGraph, Vertex, GraphData, GraphLayouts, Bag) {
     function Graph() {

--- a/src/tree/CirclePacking.js
+++ b/src/tree/CirclePacking.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/SVGWidget", "../api/ITree", "../common/Text", "../common/FAChar", "css!./CirclePacking"], factory);
     } else {
-        root.tree_CirclePacking = factory(root.d3, root.common_SVGWidget, root.tree_ITree, root.common_Text, root.common_FAChar);
+        root.tree_CirclePacking = factory(root.d3, root.common_SVGWidget, root.api_ITree, root.common_Text, root.common_FAChar);
     }
 }(this, function (d3, SVGWidget, ITree, Text, FAChar) {
     function CirclePacking(target) {

--- a/src/tree/Dendrogram.js
+++ b/src/tree/Dendrogram.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/SVGWidget", "../api/ITree", "css!./Dendrogram"], factory);
     } else {
-        root.tree_Dendrogram = factory(root.d3, root.common_SVGWidget, root.tree_ITree);
+        root.tree_Dendrogram = factory(root.d3, root.common_SVGWidget, root.api_ITree);
     }
 }(this, function (d3, SVGWidget, ITree) {
     function Dendrogram(target) {

--- a/src/tree/SunburstPartition.js
+++ b/src/tree/SunburstPartition.js
@@ -3,7 +3,7 @@
     if (typeof define === "function" && define.amd) {
         define(["d3", "../common/SVGWidget", "../api/ITree", "../common/Text", "../common/FAChar", "css!./SunburstPartition"], factory);
     } else {
-        root.tree_SunburstPartition = factory(root.d3, root.common_SVGWidget, root.tree_ITree, root.common_Text, root.common_FAChar);
+        root.tree_SunburstPartition = factory(root.d3, root.common_SVGWidget, root.api_ITree, root.common_Text, root.common_FAChar);
     }
 }(this, function (d3, SVGWidget, ITree, Text, FAChar) {
     function SunburstPartition(target) {


### PR DESCRIPTION
@GordonSmith the prefix of `amchart` is incorrect and `api` is inconsistent (used with 'api_' in amchart widgets but as tree/graph/chart in others). This pull request fixes those.