### PR TITLE
ECLWatch Support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "requirejs": "^2.1.17",
-    "requirejs-plugins": "^1.0.3",
+    "requirejs-plugins": "git://github.com/GordonSmith/requirejs-plugins.git#DOJO_AMD",
     "require-css": "^0.1.8",
     "c3": "^0.4.10",
     "colorbrewer": "^1.0.0",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,7 +153,7 @@ gulp.task("build-amd-src", function (done) {
         mainConfigFile: "src/config.js",
         modules: [{
             name: cfg.prefix,
-            include: ["requireLib", "css", "normalize"],
+            include: ["requireLib", "css", "normalize", "async", "goog", "propertyParser"],
             create: true
         }].concat(amd_modules)
     };


### PR DESCRIPTION
Added missing plugin dependencies.
Swicthed to "patched" plugins (fixed to support DOJO AMD).

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>