### PR TITLE
Popup widget #516

### DIFF
--- a/demos/dermatology.html
+++ b/demos/dermatology.html
@@ -91,6 +91,7 @@
                             <option value="src/layout/Surface">Surface Layout</option>
                             <option value="src/layout/Cell">Cell Layout</option>
                             <option value="src/layout/Grid">Grid Layout</option>
+                            <option value="src/layout/Popup">Popup Layout</option>
                             <option value="src/amchart/Area">AmChart Area</option>
                             <option value="src/amchart/Bar">AmChart Bar</option>
                             <option value="src/amchart/Bubble">AmChart Bubble</option>

--- a/src/layout/Popup.js
+++ b/src/layout/Popup.js
@@ -1,0 +1,138 @@
+"use strict";
+(function (root, factory) {
+    if (typeof define === "function" && define.amd) {
+        define(["d3", "../common/HTMLWidget", "../layout/Surface", "../form/Input", "../c3chart/Column", "css!./Popup", "css!font-awesome",], factory);
+    } else {
+        root.layout_Popup = factory(root.d3, root.common_HTMLWidget, root.layout_Surface, root.form_Input, root.c3chart_Column);
+    }
+}(this, function (d3, HTMLWidget, Surface, Input, Column) {
+    function Popup() {
+        HTMLWidget.call(this);
+
+        this._tag = "div";
+
+        this._surfaceButtons = [];
+    }
+    Popup.prototype = Object.create(HTMLWidget.prototype);
+    Popup.prototype._class += " layout_Popup";
+    
+    Popup.prototype.publish("popupState", false, "boolean", "State of the popup, visible (true) or hidden (false)",null,{});
+    Popup.prototype.publish("top", null, "number", "Top position property of popup",null,{});
+    Popup.prototype.publish("bottom", null, "number", "Bottom position property of popup",null,{});
+    Popup.prototype.publish("left", null, "number", "Left position property of popup",null,{});
+    Popup.prototype.publish("right", null, "number", "Right position property of popup",null,{});
+    Popup.prototype.publish("position", "relative", "set", "Value of the 'position' property",["absolute", "relative", "fixed", "static", "initial", "inherit" ],{tags:['Private']});
+    Popup.prototype.publish("showTestButton", false, "boolean", "Test Button in target",null,{});
+    Popup.prototype.publish("buttonName", null, "string", "Button name property",null,{});
+    Popup.prototype.publish("buttonLabel", "", "string", "Button label text",null,{});
+    Popup.prototype.publish("widget", null, "widget", "Widget",null,{tags:['Private']});
+
+
+    Popup.prototype.testData = function () {
+        this.showTestButton(true);
+        this.position("absolute");
+        this.top(30);
+        
+        var context = this;
+        this._testButton = new Input()
+            .type("button")
+            .value("Open Popup")
+            .on("click", function () {
+                context.updateState(!(context.popupState()));
+            }, true)
+        ; 
+
+        this.widget(new Surface().widget(new Column().testData()));
+
+        return this;
+    };
+
+    Popup.prototype.widgetSize = function (widgetDiv) {
+        var width = this.clientWidth() - this.calcFrameWidth(widgetDiv);
+        var height = this.clientHeight() - this.calcFrameHeight(widgetDiv);
+ 
+        return { width: width, height: height };
+    };
+    
+    Popup.prototype.updateState = function (visible) {
+            this.popupState(visible).render();
+    };
+    
+    Popup.prototype.enter = function (domNode, element) {
+        HTMLWidget.prototype.enter.apply(this, arguments);
+
+        if (this._testButton) {
+            this._testButton.target(domNode.parentNode).render();
+        }
+    };
+
+    Popup.prototype.update = function (domNode, element) {
+        HTMLWidget.prototype.update.apply(this, arguments);
+        var context = this;        
+
+        element
+            .style("position",this.position())
+            .style("left",this.left() + "px")
+            .style("right",this.right() + "px")
+            .style("top",this.top() + "px")
+            .style("bottom",this.bottom() + "px")
+        ;
+        
+        if (this.popupState()) {
+            element.style("display", "block");
+        } else {
+            element.style("display", "none");
+        }
+        
+        var widgets = element.selectAll("#" + this._id + " > .popupWidget").data(this.widget() ? [this.widget()] : [], function (d) { return d._id; });
+        widgets.enter().append("div")
+            .attr("class", "popupWidget")
+            .each(function (d) {
+                d.target(this);
+            })
+        ;
+        widgets
+            .each(function (d) {
+                var widgetSize = context.widgetSize(d3.select(this));
+                d.resize({ width: widgetSize.width, height: widgetSize.height });
+            })
+        ;
+        widgets.exit().each(function (d) {
+            d.target(null);
+        }).remove();
+        
+    };
+
+    Popup.prototype.exit = function (domNode, element) {
+        if (this.widget()) {
+            this.widget(null);
+            this.render();
+        }
+        HTMLWidget.prototype.exit.apply(this, arguments);
+    };
+
+    Popup.prototype.render = function (callback) {
+        var context = this;
+        HTMLWidget.prototype.render.call(this, function (widget) {
+            if (context.widget()) {
+                context.widget().render(function (widget) {
+                    if (callback) {
+                        callback(widget);
+                    }
+                });
+            } else {
+                if (callback) {
+                    callback(widget);
+                }
+            }
+        });
+        
+        return this;
+    };
+
+    Popup.prototype.click = function(obj) {
+        console.log("Clicked: " + obj.id);
+    };
+
+    return Popup;
+}));


### PR DESCRIPTION
@GordonSmith @mlzummo @jbrundage 

So I have refactored the Popup widget from button-controlled widget to a layout. 

Dermatology: http://rawgit.com/dtsnell4/Visualization/PopupWidget_516/demos/dermatology.html?src/layout/Popup

Basically redesigned so that you simply call yourwidget.updateState(true/false) to display and hide the widget. The test data creates a test button to do it, but with this implementation you can do it from anywhere.

Some points to consider... I can think of more advanced options, but these are the basics for me:
1.	Should we not load the widget until it is displayed the first time? If the end user never displays the popup, should we include that overhead on page load?
2.	What options should be included for closing the popup? A close button (X) in the top right? Clicking anywhere outside the popup (i.e. a modal dialog)? Include the future Titlebar widget? In my mind this could get complicated. Currently the button toggles the popup, but that’s not practical UX.
3.	Should I include a modal state option, i.e. no interaction with the page until the modal is dismissed (optional background mask)?
4.	As for positioning, should we include a default "centered" option and do the calculations automatically for the dev?

Please let me know your thoughts/comments.
