### PR TITLE
Tabbed content issue 518

### DIFF
--- a/demos/dermatology.html
+++ b/demos/dermatology.html
@@ -91,6 +91,7 @@
                             <option value="src/layout/Surface">Surface Layout</option>
                             <option value="src/layout/Cell">Cell Layout</option>
                             <option value="src/layout/Grid">Grid Layout</option>
+                            <option value="src/layout/TabbedContent">Tabbed Layout</option>
                             <option value="src/amchart/Area">AmChart Area</option>
                             <option value="src/amchart/Bar">AmChart Bar</option>
                             <option value="src/amchart/Bubble">AmChart Bubble</option>

--- a/src/layout/TabbedContent.css
+++ b/src/layout/TabbedContent.css
@@ -1,0 +1,11 @@
+.layout_TabbedContent {
+    padding: 20px;
+}
+.layout_TabbedContent .tab-button {
+    border: 1px solid #ddd;
+    background-color: transparent;
+    margin-right:5px;
+}
+.layout_TabbedContent .tab-button.active {
+    background-color: #ccc
+}

--- a/src/layout/TabbedContent.js
+++ b/src/layout/TabbedContent.js
@@ -1,0 +1,122 @@
+"use strict";
+(function (root, factory) {
+    if (typeof define === "function" && define.amd) {
+        define(["d3", "src/common/HTMLWidget", "src/api/IInput", "src/layout/Surface", "src/chart/Pie", "src/chart/MultiChart", "src/google/Line", "css!./TabbedContent"], factory);
+    } else {
+        root.form_Form = factory(root.d3, root.common_HTMLWidget, root.layout_IInput, root.layout_Surface, root.chart_Pie, root.chart_MultiChart, root.chart_Line);
+    }
+}(this, function (d3, HTMLWidget, IInput, Surface, Pie, MultiChart, Line) {
+    function TabbedContent() {
+        HTMLWidget.call(this);
+
+        this._tag = "div";
+        this._tabButtons = [];
+    }
+    TabbedContent.prototype = Object.create(HTMLWidget.prototype);
+    TabbedContent.prototype._class += " layout_TabbedContent";
+
+    TabbedContent.prototype.publish("groupClass", "", "string", "Class to identify all elements in this tab grouping",null,{});
+    TabbedContent.prototype.publish("tabAnnotations", null, "array", "Tab Array",null,{});
+
+    TabbedContent.prototype.testData = function () {
+        this.groupClass("tabTest");
+
+        this.tabAnnotations([
+            {
+                id:"tab_1",
+                label:"MultiChart",
+                width:80,
+                padding:"3px",
+                class: "active",
+                content: new Surface().widget(new MultiChart().testData())
+            },{
+                id:"tab_2",
+                label:"Pie Chart",
+                width:80,
+                padding:"3px",
+                class:"",
+                content: new Surface().widget(new Pie().testData())
+            },{
+                id:"tab_3",
+                label:"Line Chart",
+                width:80,
+                padding:"3px",
+                class:"",
+                content: new Surface().widget(new Line().testData())
+            }
+        ]);
+
+        return this;
+    };
+
+    TabbedContent.prototype.widgetSize = function (widgetDiv) {
+        var width = this.clientWidth() - this.calcFrameWidth(widgetDiv);
+        var height = this.clientHeight() - this.calcFrameHeight(widgetDiv);
+ 
+        return { width: width, height: height };
+    };
+    
+    TabbedContent.prototype.createContainers = function (element) {
+        element.classed(this.groupClass(), true);
+        
+        this._tabContainer = element.append("div").attr("class", "tabContainer").selectAll(".tab-button").data(this.tabAnnotations());
+        
+        var context = this;
+        this._tabContainer.enter().append("span").classed("tab-button",true)
+            .each(function (tab, idx) {
+                var el = context._tabButtons[idx] = d3.select(this)
+                    .attr("class", "tab-button " + tab.class)
+                    .attr("for", tab.id)
+                    .style('padding', tab.padding)
+                    .style('width', tab.width)
+                    .style('height', tab.height)
+                    .style("cursor","pointer")
+                    .html(function(d) { return tab.label; })
+                    .on("click", function(d) { 
+                        var cls = context.groupClass() === "" ? "" : "." + context.groupClass() + " ";
+                        d3.selectAll(cls + ".tab-button")
+                            .classed("active", false);
+                        el.classed("active", true);
+                        d3.selectAll(cls + ".tab-content")
+                            .style("display", "none")
+                            .classed("active", false);
+                        d3.select("#" + tab.id)
+                            .style("display", "block")
+                            .classed("active", true);
+                    })
+                ;
+            }
+        );
+
+        this._contentContainer = element.append("div").attr("class", "contentContainer").selectAll(".tab-content").data(this.tabAnnotations());
+        this._contentContainer.enter().append("div").classed("tab-content",true)
+            .each(function (tab, idx) {
+                var el = context._tabButtons[idx] = d3.select(this)
+                    .attr("class", "tab-content")
+                    .attr("id", tab.id)
+                    .style("display", "none")
+                ;
+                if (tab.class === "active") {
+                    el.style("display", "block");
+                    el.classed("active", true);
+                }
+                el
+                    .style('width', context.widgetSize(el).width + "px")
+                    .style('height', context.widgetSize(el).height + "px")
+                ;
+                tab.content.target(tab.id).render();
+            }
+        );
+    };
+    
+    TabbedContent.prototype.enter = function (domNode, element) {
+        HTMLWidget.prototype.enter.apply(this, arguments);
+        this.createContainers(element);
+    };
+
+    TabbedContent.prototype.update = function () {
+        HTMLWidget.prototype.update.apply(this, arguments);
+    };
+
+    return TabbedContent;
+}));


### PR DESCRIPTION
@GordonSmith @jbrundage @mlzummo 

Similar to the Popup widget, here is a basic implementation of the Tabbed widget.  I used an array to pass the data similar to how we did the Surface Buttons.  

Demo here: http://rawgit.com/dtsnell4/Visualization/Tabbed_Content_518/demos/dermatology.html?src/layout/TabbedContent

The problem I have with that approach is passing the widget in the array.  If you inspect the console when running the demo, you will see an error "Uncaught TypeError: Converting circular structure to JSON" which is caused by the widget.  However everything runs and is displayed fine and works as expected, but I'm obviously uncomfortable with that.  If I pass the widget as a publish parameter that error goes away obviously, but that is not practical for this implementation with an unknown number of tabs/widgets.  If anyone has any suggestions on another way to do this please let me know, as well as other comments.  