### PR TITLE
GH-573 Persist now uses the correct key for deserialization of "widget" type publish parameters

### DIFF
--- a/src/other/Persist.js
+++ b/src/other/Persist.js
@@ -103,8 +103,9 @@
                         switch (widget["__meta_" + key].type) {
                             case "widget":
                                 ++createCount;
+                                var widgetKey = key;
                                 context.deserialize(state.__properties[key], function (widgetItem) {
-                                    widget[key](widgetItem);
+                                    widget[widgetKey](widgetItem);
                                     --createCount;
                                 });
                                 break;


### PR DESCRIPTION
Fixes GH-573 

@GordonSmith @mlzummo @dtsnell4 Please Review

Signed-off-by: Jay Brundage <jaman.brundage@lexisnexis.com>