### PR TITLE
GH-619 "null" values and "Date" values causes errors.

### DIFF
--- a/src/chart/XYAxis.js
+++ b/src/chart/XYAxis.js
@@ -160,7 +160,7 @@
             .data([
                 ["Geography", "2010-07-09"],
                 ["English", "2010-07-12"],
-                ["Math", "2010-07-15"],
+                ["Math", null],
                 ["Science", "2010-07-21"]
             ])
         ;
@@ -198,6 +198,9 @@
     };
 
     XYAxis.prototype.formatValue = function (d) {
+        if (!d) {
+            return d;
+        }
         if (d instanceof Array) {
             return d.map(function (item) {
                 return this.formatValue(item);


### PR DESCRIPTION
Do not attempt to format "null/undefined/empty" values.

Fixes GH-619

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>