### PR TITLE
GH-573 Persist now uses correct key for "widget" param deserialize

### DIFF
--- a/src/other/Persist.js
+++ b/src/other/Persist.js
@@ -103,8 +103,9 @@
                         switch (widget["__meta_" + key].type) {
                             case "widget":
                                 ++createCount;
+                                var widgetKey = key;
                                 context.deserialize(state.__properties[key], function (widgetItem) {
-                                    widget[key](widgetItem);
+                                    widget[widgetKey](widgetItem);
                                     --createCount;
                                 });
                                 break;


### PR DESCRIPTION
Fixes GH-573

This applies to deserializing "widget" type publish parameters.

@GordonSmith Please Review

Signed-off-by: Jay Brundage <jaman.brundage@lexisnexis.com>