### PR TITLE
GH-582 Table columns render in wrong sequence

### DIFF
--- a/src/other/Table.js
+++ b/src/other/Table.js
@@ -99,7 +99,7 @@
         HTMLWidget.prototype.update.apply(this, arguments);
         var context = this;
 
-        var th = this.thead.selectAll("th").data(this._columns, function (d) { return d;});
+        var th = this.thead.selectAll("th").data(this._columns);
         th
             .enter()
             .append("th")


### PR DESCRIPTION
Adding/removing or editing the columns will cause them to lose their correct order.

Fixes GH-582

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>