### PR TITLE
Published Array Initialization

### DIFF
--- a/src/common/Widget.js
+++ b/src/common/Widget.js
@@ -34,6 +34,17 @@
         this._size = { width: 0, height: 0 };
         this._scale = 1;
 
+        for (var key in this) {
+            if (key.indexOf("__meta_") === 0) {
+                switch (this[key].type) {
+                    case "array":
+                    case "widgetArray":
+                        this["__prop_" + this[key].id] = [];
+                        break;
+                }
+            }
+        }
+
         this._target = null;
         this._parentElement = null;
         this._parentWidget = null;


### PR DESCRIPTION
Published arrays need to be initialized at construction otherwise the default array in the __meta_ will be used as a Class Static instance (shared by all).

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>