### PR TITLE
GH-768 PropertyEditor excl tags do not propagate

### DIFF
--- a/src/c3chart/Area.js
+++ b/src/c3chart/Area.js
@@ -19,7 +19,7 @@
     Area.prototype.publish("lineWidth", 1.0, "number", "Line Width",null,{tags:["Basic","Shared"]});
     Area.prototype.publish("lineDashStyle", [], "array", "Dashed Lines",null,{tags:["Basic","Shared"]});
     Area.prototype.publish("lineOpacity", 1.0, "number", "Line Alpha",null,{tags:["Basic","Shared"]});
-    Area.prototype.publish("fillOpacity", 0.2, "number", "Opacity of The Fill Color",null,{tags:["Basic","Exp","Shared"]});
+    Area.prototype.publish("fillOpacity", 0.2, "number", "Opacity of The Fill Color", null, { tags: ["Basic", "Shared"] });
 
     Area.prototype.enter = function (domNode, element) {
         CommonND.prototype.enter.apply(this, arguments);

--- a/src/common/Surface.js
+++ b/src/common/Surface.js
@@ -51,7 +51,7 @@
     Surface.prototype.publish("showTitle", true, "boolean", "Show Title",null,{tags:["Basic"]});
     Surface.prototype.publish("title", "", "string", "Title",null,{tags:["Basic"]});
     Surface.prototype.publishProxy("titleFontSize", "_text", "fontSize");
-    Surface.prototype.publish("showIcon", true, "boolean", "Show Title",null,{tags:["Advance"]});
+    Surface.prototype.publish("showIcon", true, "boolean", "Show Title",null,{tags:["Advanced"]});
     Surface.prototype.publishProxy("icon_faChar", "_icon", "faChar");
     Surface.prototype.publishProxy("icon_shape", "_icon", "shape");
     //Surface.prototype.publish("menu");

--- a/src/common/Text.js
+++ b/src/common/Text.js
@@ -13,11 +13,11 @@
     Text.prototype.constructor = Text;
     Text.prototype._class += " common_Text";
 
-    Text.prototype.publish("text", "", "string", "Display Text",null,{tags:["Private"]});
-    Text.prototype.publish("fontFamily", "", "string", "Font Family",null,{tags:["Private"]});
-    Text.prototype.publish("fontSize", null, "number", "Font Size (px)",null,{tags:["Private"]});
-    Text.prototype.publish("anchor", "middle", "set", "Anchor Position", ["start", "middle", "end"],{tags:["Private"]});
-    Text.prototype.publish("colorFill", null, "html-color", "Fill Color",null,{tags:["Private"]});
+    Text.prototype.publish("text", "", "string", "Display Text",null,{tags:["Basic"]});
+    Text.prototype.publish("fontFamily", "", "string", "Font Family",null,{tags:["Intermediate"]});
+    Text.prototype.publish("fontSize", null, "number", "Font Size (px)", null, { tags: ["Intermediate"] });
+    Text.prototype.publish("anchor", "middle", "set", "Anchor Position", ["start", "middle", "end"], { tags: ["Intermediate"] });
+    Text.prototype.publish("colorFill", null, "html-color", "Fill Color", null, { tags: ["Basic"] });
 
     Text.prototype.testData = function () {
         this.text("Hello\nand\nWelcome!");

--- a/src/other/PropertyEditor.js
+++ b/src/other/PropertyEditor.js
@@ -247,6 +247,12 @@
         } else if (context._showing_themeMode !== context.themeMode()) {
             needsRedraw = true;
         }
+        if (typeof (context._prevExcludeTags) === "undefined") {
+            context._prevExcludeTags = JSON.stringify(context.excludeTags());
+        } else if (context._prevExcludeTags !== JSON.stringify(context.excludeTags())) {
+            context._prevExcludeTags = JSON.stringify(context.excludeTags());
+            needsRedraw = true;
+        }
         return needsRedraw;
     };
     PropertyEditor.prototype.widgetPropertyModified = function (widget, propID) {
@@ -831,6 +837,7 @@
                                             .paramGrouping("By Widget")
                                             .showColumns(context.showColumns())
                                             .showData(context.showData())
+                                            .excludeTags(context.excludeTags())
                                             .show_settings(false)
                                             .target(input.node())
                                         ;

--- a/test/widgets.js
+++ b/test/widgets.js
@@ -147,6 +147,29 @@
                     });
                 });
 
+                it("Property Tags", function (done) {
+                    require([path, "src/other/Persist"], function (Widget, Persist) {
+                        var widget = new Widget();
+                        Persist.discover(widget).forEach(function (prop) {
+                            if (prop.ext && prop.ext.tags) {
+                                prop.ext.tags.forEach(function (tag) {
+                                    switch (tag) {
+                                        case "Basic":
+                                        case "Intermediate":
+                                        case "Advanced":
+                                        case "Private":
+                                        case "Shared":
+                                            break;
+                                        default:
+                                            assert.isTrue(false, "Invalid property tag:  '" + tag + "'");
+                                    }
+                                });
+                            }
+                        });
+                        done();
+                    });
+                });
+
                 var noSurfaceHTML = null;
                 it("Adding widget to the page", function (done) {
                     require([path], function (Widget) {


### PR DESCRIPTION
When exclude tags are changed at the root level, it should force a re-calc of
the property editor tree.

Fixes GH-768

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>