### PR TITLE
GH-823 GOOGLE DRAW ERROR

### DIFF
--- a/src/google/Common.js
+++ b/src/google/Common.js
@@ -14,7 +14,7 @@
 
         this.columns([]);
         this.data([]);
-        this._data_google = [];
+        this._data_google = google.visualization.arrayToDataTable([["", { role: "annotation" }],["",""]]);
 
         this._chart = null;
     }


### PR DESCRIPTION
@GordonSmith @dineshshetye Please Review

Fixes draw error thrown by google when draw is initialized for the first time before it can be converted to a google dataArray obj

Fixes GH-823

Signed-off-by: Mathew Zummo <mzummo@gmail.com>