### PR TITLE
GH-455 Adds showProperties to PropertyEditor

### DIFF
--- a/demos/dermatology.html
+++ b/demos/dermatology.html
@@ -193,9 +193,13 @@
         var currWidget = null;
         var showProperties = null;
         var debouncedResize = null;
+        var propEditor = null;
 
         require(["src/layout/Surface", "src/layout/Grid", "src/other/Persist", "src/other/PropertyEditor"], function (Surface, Grid, Persist, PropertyEditor) {
-            var propEditor = new PropertyEditor().showColumns(false).showData(false);
+            propEditor = new PropertyEditor()
+                    .showColumns(false)
+                    .showData(false)
+            ;
             propEditor.onChange =  Surface.prototype.debounce(function (widget, propID) {
                 if (propID === "columns") {
                 } else if (propID === "data") {


### PR DESCRIPTION
Fixes GH-455

An array of publish param IDs can be passed to PropertyEditor.showProperties() to restrict all other publish parameters from displaying in the PropertyEditor.

@prakash-sukumar @GordonSmith Please Review

Signed-off-by: Jay Brundage <jaman.brundage@lexisnexis.com>