### PR TITLE
GH-914 Switching tabs slow and resizes widget

### DIFF
--- a/src/api/ITooltip.js
+++ b/src/api/ITooltip.js
@@ -32,11 +32,11 @@
                 .data([idx === undefined ? row : [row[0], row[idx]]])
                 .text(row[0] + ", " + _columns[idx] + ":  " + row[idx])
             ;
-            if (this._tooltip._renderCount === 0) {
+            if (!this._tooltip._target) {
                 this._tooltip
                     .target(this._parentOverlay.node())
                     .render(function (w) {
-                        context._textBox._parentElement.style("overflow", "hidden");
+                        return context._textBox._parentElement ? context._textBox._parentElement.style("overflow", "hidden") : {};
                     })
                 ;
             } else {

--- a/src/common/Menu.js
+++ b/src/common/Menu.js
@@ -22,7 +22,7 @@
             context.hideMenu();
             context.click(d);
         };
-        this._visible = false;
+        this._open = false;
     }
     Menu.prototype = Object.create(SVGWidget.prototype);
     Menu.prototype.constructor = Menu;
@@ -33,7 +33,7 @@
     Menu.prototype.publishProxy("paddingPercent", "_icon", null, 10);
 
     Menu.prototype.toggleMenu = function () {
-        if (!this._visible) {
+        if (!this._open) {
             this.showMenu();
         } else {
             this.hideMenu();
@@ -42,7 +42,7 @@
 
     Menu.prototype.showMenu = function () {
         this.preShowMenu();
-        this._visible = true;
+        this._open = true;
         this._list
             .data(this.data())
             .render()
@@ -61,7 +61,7 @@
         d3.select("body")
             .on("click." + this._id, function () {
                 console.log("click:  body - " + context._id);
-                if (context._visible) {
+                if (context._open) {
                     context.hideMenu();
                 }
             })
@@ -72,7 +72,7 @@
         d3.select("body")
             .on("click." + this._id, null)
         ;
-        this._visible = false;
+        this._open = false;
         this._list
             .data([])
             .render()

--- a/src/common/Widget.js
+++ b/src/common/Widget.js
@@ -31,6 +31,7 @@
         this._pos = { x: 0, y: 0 };
         this._size = { width: 0, height: 0 };
         this._scale = 1;
+        this._visible = true;
 
         for (var key in this) {
             if (key.indexOf("__meta_") === 0) {
@@ -689,6 +690,10 @@
     //  Render  ---
     Widget.prototype.render = function (callback) {
         callback = callback || function () { };
+        if (!this.visible()) {
+            callback(this);
+            return this;
+        }
         if (this._parentElement) {
             if (!this._tag)
                 throw "No DOM tag specified";

--- a/src/layout/Tabbed.js
+++ b/src/layout/Tabbed.js
@@ -27,7 +27,7 @@
         return this;
     };
 
-    Tabbed.prototype.addTab = function (widget, label, isActive) {
+    Tabbed.prototype.addTab = function (widget, label, isActive, callback) {
         var widgetSize = widget.size();
         if(widgetSize.width === 0 && widgetSize.height === 0){
             widget.size({width:"100%",height:"100%"});
@@ -38,9 +38,13 @@
             this.activeTabIdx(this.widgets().length);
         }
         labels.push(label);
-        widgets.push(new Surface().widget(widget ? widget : new Text().text("No widget defined for tab")));
+        var surface = new Surface().widget(widget ? widget : new Text().text("No widget defined for tab"));
+        widgets.push(surface);
         this.labels(labels);
         this.widgets(widgets);
+        if (callback) {
+            callback(surface);
+        }
         return this;
     };
 
@@ -72,6 +76,7 @@
             .attr("class", "tab-button id" + this.id())
             .style("cursor", "pointer")
             .on("click", function (d, idx) {
+                context.click(context.widgets()[idx].widget(), d, idx);
                 context
                     .activeTabIdx(idx)
                     .render()
@@ -95,12 +100,15 @@
             .classed("active", function (d, idx) { return context.activeTabIdx() === idx; })
             .style("display", function (d, idx) { return context.activeTabIdx() === idx ? "block" : "none"; })
             .each(function (surface, idx) {
-                var wSize = context.widgetSize(d3.select(this));
-                surface
-                    .surfaceBorderWidth(context.showTabs() ? null : 0)
-                    .surfacePadding(context.showTabs() ? null : 0)
-                    .resize(wSize)
-                ;
+                surface.visible(context.activeTabIdx() === idx);
+                if (context.activeTabIdx() === idx) {
+                    var wSize = context.widgetSize(d3.select(this));
+                    surface
+                        .surfaceBorderWidth(context.showTabs() ? null : 0)
+                        .surfacePadding(context.showTabs() ? null : 0)
+                        .resize(wSize)
+                    ;
+                }
             })
         ;
         content.exit()
@@ -110,6 +118,9 @@
                 ;
             })
             .remove();
+    };
+
+    Tabbed.prototype.click = function (widget, column, idx) {
     };
 
     return Tabbed;

--- a/test/layoutFactory.js
+++ b/test/layoutFactory.js
@@ -240,7 +240,7 @@
                             new Line()
                                 .columns(DataFactory.ND.subjects.columns)
                                 .data(DataFactory.TwoD.subjects.data)
-                            , "Line CHart")
+                            , "Line Chart")
                         .addTab(
                             new Column()
                                 .columns(DataFactory.ND.subjects.columns)


### PR DESCRIPTION
Changes the way tabs are hidden from "display: none/block" to using the Widget.prototype.visible() method so that content panels can be shown/hidden in the DOM without re-rendering the widget. Also removes the extra content panel div in favor of the Surface widget parent div

Fixes GH-914

Signed-off-by: Dan Snell <Dan.Snell@lexisnexis.com>