### PR TITLE
GH-749 Add Second Y Axis to Google Charts

### DIFF
--- a/demos/test-no-amd.html
+++ b/demos/test-no-amd.html
@@ -82,7 +82,7 @@
     <script>
         google.load("visualization", "1", {
             callback: doTest,
-            packages: ["corechart", "timeline", "treemap"]
+            packages: ["corechart", "timeline", "treemap", "bar", "line", "scatter"]
         });
     </script>
 </body>

--- a/src/google/Bar.js
+++ b/src/google/Bar.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "./CommonND"], factory);
+        define(["d3", "./CommonND", "goog!visualization,1.1,packages:[bar]"], factory);
     } else {
         root.google_Bar = factory(root.d3, root.google_CommonND);
     }
@@ -17,6 +17,7 @@
     Bar.prototype._class += " google_Bar";
 
     Bar.prototype.publish("isStacked", false, "boolean", "Stacks the elements in a series",null,{tags:["Basic","Shared"]});
+    Bar.prototype.publish("orientation", "horizontal", "set", "Horizontal (Bar Chart) or Vertical (Column Chart) orientation",["horizontal", "vertical"],{tags:["Basic","Shared"]});
     //opacity?
     Bar.prototype.publish("axisFontSize", null, "number", "X/Y Axis Label Font Size",null,{tags:["Basic","Shared"]});
     Bar.prototype.publish("axisFontFamily", null, "string", "X/Y Axis Label Font Name",null,{tags:["Basic","Shared"]});
@@ -38,7 +39,9 @@
 
     Bar.prototype.publish("xAxisTitleFontFamily", null, "string", "Horizontal Axis Title Text Style (Font Name)",null,{tags:["Intermediate","Shared"]});
     Bar.prototype.publish("yAxisTitleFontFamily", null, "string", "Vertical Axis Title Text Style (Font Name)",null,{tags:["Intermediate","Shared"]});
-
+    Bar.prototype.publish("yAxisPrimaryLabel", null, "string", "Top or Left Y axis label for dual y-axes series data","",{tags:["Basic","Shared"]});
+    Bar.prototype.publish("yAxisSecondaryLabel", null, "string", "Bottom or Right Y axis label for dual y-axes series data","",{tags:["Basic","Shared"]});
+    
     Bar.prototype.publish("xAxisLabelRotation", 0, "number", "X Axis Label Angle",null,{tags:["Intermediate","Shared"]});
 
     Bar.prototype.publish("groupWidth", "", "string", "The width of a group of bars, Percent or Pixels",null,{tags:["Advanced"]});
@@ -94,9 +97,29 @@
 
         retVal.dataOpacity = this.dataOpacity();
         retVal.isStacked = this.isStacked();
+        retVal.bars = this.orientation();
         retVal.bar = {
             groupWidth: this.groupWidth()
         };
+
+        if (this.yAxisSecondaryLabel()) {
+            retVal.series =  {
+                0: { axis: "primary" },
+                1: { axis: "secondary" }
+            };
+            var side, ax;
+            if (this.orientation() === "horizontal") {
+                side = "top";
+                ax = "x";
+            } else {
+                side = "right";
+                ax = "y";
+            }
+            retVal.axes[ax] = {
+                  primary: {label: this.yAxisPrimaryLabel()},
+                  secondary: {side: side, label: this.yAxisSecondaryLabel()}
+            };
+        }
 
         retVal.hAxis = {};
         retVal.vAxis = {};
@@ -179,10 +202,12 @@
             min: this.yAxisViewWindowMin(),
             max: this.yAxisViewWindowMax()
         };
+        retVal = google.charts.Bar.convertOptions(retVal);
         return retVal;
     };
 
     Bar.prototype.enter = function (domNode, element) {
+        this._chart = new google.charts.Bar(domNode);
         CommonND.prototype.enter.apply(this, arguments);
     };
 

--- a/src/google/Common.js
+++ b/src/google/Common.js
@@ -137,8 +137,8 @@
 
     Common.prototype.enter = function (domNode, element) {
         element.style("overflow", "hidden");
-
-        this._chart = new google.visualization[this._chartType](domNode);
+        
+        this._chart = this._chart ? this._chart : new google.visualization[this._chartType](domNode);
 
         var context = this;
         google.visualization.events.addListener(this._chart, "select", function () {

--- a/src/google/Line.js
+++ b/src/google/Line.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "./CommonND"], factory);
+        define(["d3", "./CommonND", "goog!visualization,1.1,packages:[line]"], factory);
     } else {
         root.google_Line = factory(root.d3, root.google_CommonND);
     }
@@ -39,6 +39,8 @@
 
     Line.prototype.publish("xAxisTitleFontFamily", null, "string", "Horizontal Axis Title Text Style (Font Name)",null,{tags:["Intermediate","Shared"]});
     Line.prototype.publish("yAxisTitleFontFamily", null, "string", "Vertical Axis Title Text Style (Font Name)",null,{tags:["Intermediate","Shared"]});
+    Line.prototype.publish("yAxisPrimaryLabel", null, "string", "Top or Left Y axis label for dual y-axes series data","",{tags:["Basic","Shared"]});
+    Line.prototype.publish("yAxisSecondaryLabel", null, "string", "Bottom or Right Y axis label for dual y-axes series data","",{tags:["Basic","Shared"]});
 
     Line.prototype.publish("xAxisLabelRotation", 0, "number", "X Axis Label Angle",null,{tags:["Intermediate","Shared"]});
 
@@ -106,6 +108,28 @@
         retVal.orientation = this.orientation();
         retVal.pointShape = this.pointShape();
         retVal.pointSize = this.pointSize();
+        
+        if (this.yAxisSecondaryLabel()) {
+            retVal.series =  {
+                0: { 
+                    axis: "primary" 
+                },
+                1: { 
+                    axis: "secondary" 
+                }
+            };
+            retVal.axes = {
+                y: {
+                    primary: {
+                        label: this.yAxisPrimaryLabel()
+                },
+                    secondary: {
+                        side: "right", 
+                        label: this.yAxisSecondaryLabel()
+                    }
+                }
+            };
+        }
 
         retVal.hAxis = {};
         retVal.vAxis = {};
@@ -217,11 +241,13 @@
         if (this.smoothLines()) {
             retVal.curveType = "function";
         }
-
+        
+        retVal = google.charts.Line.convertOptions(retVal);
         return retVal;
     };
 
     Line.prototype.enter = function (domNode, element) {
+        this._chart = new google.charts.Line(domNode);
         CommonND.prototype.enter.apply(this, arguments);
     };
 

--- a/src/google/Scatter.js
+++ b/src/google/Scatter.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "./CommonND", "../common/HTMLWidget"], factory);
+        define(["d3", "./CommonND", "../common/HTMLWidget",  "goog!visualization,1.1,packages:[scatter]"], factory);
     } else {
         root.google_Scatter = factory(root.d3, root.google_CommonND, root.common_HTMLWidget);
     }
@@ -54,6 +54,9 @@
 
     Scatter.prototype.publish("xAxisTitleFontFamily", null, "string", "Horizontal Axis Title Text Style (Font Name)",null,{tags:["Intermediate","Shared"]});
     Scatter.prototype.publish("yAxisTitleFontFamily", null, "string", "Vertical Axis Title Text Style (Font Name)",null,{tags:["Intermediate","Shared"]});
+    Scatter.prototype.publish("yAxisPrimaryLabel", null, "string", "Top or Left Y axis label for dual y-axes series data","",{tags:["Basic","Shared"]});
+    Scatter.prototype.publish("yAxisSecondaryLabel", null, "string", "Bottom or Right Y axis label for dual y-axes series data","",{tags:["Basic","Shared"]});
+
 
     Scatter.prototype.publish("xAxisLabelRotation", 0, "number", "X Axis Label Angle",null,{tags:["Intermediate","Shared"]});
 
@@ -119,6 +122,28 @@
             opacity: this.crosshairOpacity(),
             trigger: this.crosshairTrigger()
         };
+        
+         if (this.yAxisSecondaryLabel()) {
+            retVal.series =  {
+                0: { 
+                    axis: "primary" 
+                },
+                1: { 
+                    axis: "secondary" 
+                }
+            };
+            retVal.axes = {
+                y: {
+                    primary: {
+                        label: this.yAxisPrimaryLabel()
+                },
+                    secondary: {
+                        side: "right", 
+                        label: this.yAxisSecondaryLabel()
+                    }
+                }
+            };
+        }
 
         retVal.hAxis = {};
         retVal.vAxis = {};
@@ -193,11 +218,13 @@
             min: this.yAxisViewWindowMin(),
             max: this.yAxisViewWindowMax()
         };
-
+        
+        retVal = google.charts.Scatter.convertOptions(retVal);
         return retVal;
     };
 
     Scatter.prototype.enter = function (domNode, element) {
+        this._chart = new google.charts.Scatter(domNode);
         CommonND.prototype.enter.apply(this, arguments);
     };
 

--- a/test/runner_build_nonamd.html
+++ b/test/runner_build_nonamd.html
@@ -70,7 +70,7 @@
     <script>
         google.load("visualization", "1", {
             callback: function () { mocha.run(); },
-            packages: ["corechart", "timeline", "treemap"]
+            packages: ["corechart", "timeline", "treemap", "bar", "line", "scatter"]
         });
     </script>
 </body>


### PR DESCRIPTION
Updates Google Bar/Column, Line and Scatter charts to latest Google Material Charts version.  Implements the "axes" and "series" options to create dual-y axes.

Fixes GH-749

Signed-off-by: Dan Snell <Dan.Snell@lexisnexis.com>