### PR TITLE
GH-946 Standardizes layout padding params

### DIFF
--- a/apps/SampleSite/legend.html
+++ b/apps/SampleSite/legend.html
@@ -57,7 +57,7 @@
                 main = new Grid()
                     .setContent(0, 0, widget)
                     .setContent(0, 1, legend)
-                    .cellPadding(0)
+                    .surfacePadding(0)
                 ;
 
                 frame = new Surface()

--- a/demos/dermatology.html
+++ b/demos/dermatology.html
@@ -237,7 +237,7 @@
             ;
             main = new Grid()
                 .setContent(0, 2, propEditor, "", 2, 1)
-                .cellPadding(0)
+                .surfacePadding(0)
             ;
 
             frame = new Surface()

--- a/src/layout/Border.js
+++ b/src/layout/Border.js
@@ -48,7 +48,7 @@
     Border.prototype.publish("rightPercentage", 20, "number", "Percentage (of parent) Width of the 'Right' Cell",null,{tags:["Private"]});
     Border.prototype.publish("bottomPercentage", 20, "number", "Percentage (of parent) Height of the 'Bottom' Cell",null,{tags:["Private"]});
 
-    Border.prototype.publish("cellPadding", 0, "number", "Cell Padding (px)", null, { tags: ["Intermediate"] });
+    Border.prototype.publish("surfacePadding", 0, "number", "Cell Padding (px)", null, { tags: ["Intermediate"] });
 
 
     Border.prototype.publish("sectionTypes", [], "array", "Section Types sharing an index with 'content' - Used to determine position/size.", null, { tags: ["Private"] });
@@ -403,7 +403,7 @@
                         .attr("draggable", context.designMode())
                 ;
                 d
-                    .surfacePadding(context.cellPadding())
+                    .surfacePadding(context.surfacePadding())
                     .resize()
                 ;
             });

--- a/src/layout/Grid.js
+++ b/src/layout/Grid.js
@@ -30,7 +30,7 @@
     Grid.prototype.publish("designGridColor", "#ddd", "html-color", "Color of grid lines in Design Mode",null,{tags:["Private"]});
     Grid.prototype.publish("designGridColorExtra", "#333333", "html-color", "Color of excess grid lines in Design Mode",null,{tags:["Private"]});
 
-    Grid.prototype.publish("cellPadding", null, "string", "Cell Padding (px)", null, { tags: ["Intermediate"] });
+    Grid.prototype.publish("surfacePadding", null, "string", "Cell Padding (px)", null, { tags: ["Intermediate"] });
     
     Grid.prototype.publish("extraDesignModeWidth", 2, "number", "Number of additional columns added when in Design Mode.",null,{tags:["Private"]});
     Grid.prototype.publish("extraDesignModeHeight", 2, "number", "Number of additional rows added when in Design Mode.",null,{tags:["Private"]});
@@ -439,7 +439,7 @@
                 ;
 
                 d
-                    .surfacePadding(context.cellPadding())
+                    .surfacePadding(context.surfacePadding())
                     .resize()
                 ;
             });

--- a/src/layout/Layered.js
+++ b/src/layout/Layered.js
@@ -15,7 +15,7 @@
     Layered.prototype.constructor = Layered;
     Layered.prototype._class += " layout_Layered";
 
-    Layered.prototype.publish("padding", 0, "number", "Padding");
+    Layered.prototype.publish("surfacePadding", 0, "number", "Padding");
 
     Layered.prototype.publish("widgets", [], "widgetArray", "widgets", null, { tags: ["Private"] });
 
@@ -37,7 +37,7 @@
         HTMLWidget.prototype.update.apply(this, arguments);
         var context = this;
 
-        element.style("padding", this.padding() + "px");
+        element.style("padding", this.surfacePadding() + "px");
 
         var content = this._contentContainer.selectAll(".content.id" + this.id()).data(this.widgets(), function (d) { return d.id(); });
         content.enter().append("div")

--- a/src/layout/Tabbed.js
+++ b/src/layout/Tabbed.js
@@ -16,7 +16,7 @@
     Tabbed.prototype._class += " layout_Tabbed";
 
     Tabbed.prototype.publish("showTabs", true, "boolean", "Show Tabs", null, {});
-    Tabbed.prototype.publish("padding", 4, "number", "Padding");
+    Tabbed.prototype.publish("surfacePadding", 4, "number", "Padding");
     Tabbed.prototype.publish("activeTabIdx", 0, "number", "Index of active tab", null, {});
 
     Tabbed.prototype.publish("labels", [], "array", "Array of tab labels sharing an index with ", null, { tags: ["Private"] });
@@ -61,7 +61,7 @@
         HTMLWidget.prototype.update.apply(this, arguments);
         var context = this;
 
-        element.style("padding", this.padding() + "px");
+        element.style("padding", this.surfacePadding() + "px");
 
         var tabs = this._tabContainer.selectAll(".tab-button.id" + this.id()).data(this.showTabs() ? this.labels() : [], function (d) { return d; });
         tabs.enter().append("span")


### PR DESCRIPTION
Fixes GH-946

The **padding** and **cellPadding** publish params have been renamed to **surfacePadding**. 

Note: The Layered and Tabbed layouts currently don't use Surface objects. If you'd prefer a different name because of that fact, that's understandable. Otherwise, **surfacePadding** is a clear indication of functionality.

@GordonSmith Please review

Signed-off-by: Jay Brundage <jaman.brundage@lexisnexis.com>