### PR TITLE
GH-1002 Fixes PropEdit looping bug in DSP

### DIFF
--- a/src/other/PropertyEditor.js
+++ b/src/other/PropertyEditor.js
@@ -149,7 +149,7 @@
 
                 this.removeWatches();
 
-                for(var i in this.data()) {
+                for(var i=0;i<this.data().length;i++) {
                     this.createWatch(this.data()[i]);
                     var paramArr2 = [];
                     var parentWidgetClass = this.data()[i]._class.split("_").pop();
@@ -173,7 +173,7 @@
                                 if(!context.excludeWidgets()){
                                     var w = widget[param.id]();
                                     var wClassArr = [];
-                                    for(var widx in w){
+                                    for(var widx=0;widx<w.length;widx++){
                                         wClassArr.push(w[widx]._class.split("_").pop());
                                     }
                                     context.pushListItem(


### PR DESCRIPTION
Fixes GH-1002

Converts two for ... in loops to for(var x=0;x<arr.length;x++) loops to resolve a JS conflict with a one of DSP's js framework files.

@mlzummo @GordonSmith @dtsnell4 @jchambers-ln

More can be read about it here:
http://stackoverflow.com/questions/8262128/javascript-for-loop-returning-key-indexof

Signed-off-by: Jay Brundage <jaman.brundage@lexisnexis.com>