### PR TITLE
GH-995 Google Material Chart Loading Issue

### DIFF
--- a/src/google/Area.js
+++ b/src/google/Area.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "./CommonND"], factory);
+        define(["d3", "./CommonND", "goog!visualization,1,packages:[corechart]"], factory);
     } else {
         root.google_Area = factory(root.d3, root.google_CommonND);
     }

--- a/src/google/Column.js
+++ b/src/google/Column.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "./CommonND"], factory);
+        define(["d3", "./CommonND", "goog!visualization,1,packages:[corechart]"], factory);
     } else {
         root.google_Column = factory(root.d3, root.google_CommonND);
     }

--- a/src/google/Common.js
+++ b/src/google/Common.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "../common/HTMLWidget", "goog!visualization,1,packages:[corechart]"], factory);
+        define(["d3", "../common/HTMLWidget"], factory);
     } else {
         root.google_Common = factory(root.d3, root.common_HTMLWidget);
     }

--- a/src/google/Common2D.js
+++ b/src/google/Common2D.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "../google/Common", "../api/I2DChart", "goog!visualization,1,packages:[corechart]"], factory);
+        define(["d3", "../google/Common", "../api/I2DChart"], factory);
     } else {
         root.google_Common2D = factory(root.d3, root.google_Common, root.api_I2DChart);
     }

--- a/src/google/CommonND.js
+++ b/src/google/CommonND.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "../google/Common", "../api/INDChart", "goog!visualization,1,packages:[corechart]"], factory);
+        define(["d3", "../google/Common", "../api/INDChart"], factory);
     } else {
         root.google_CommonND = factory(root.d3, root.google_Common, root.api_INDChart);
     }

--- a/src/google/Pie.js
+++ b/src/google/Pie.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "./Common2D"], factory);
+        define(["d3", "./Common2D", "goog!visualization,1,packages:[corechart]"], factory);
     } else {
         root.google_Pie = factory(root.d3, root.google_Common2D);
     }

--- a/src/google/Scatter.js
+++ b/src/google/Scatter.js
@@ -1,7 +1,7 @@
 "use strict";
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["d3", "./CommonND", "../common/HTMLWidget",  "goog!visualization,1.1,packages:[scatter]"], factory);
+        define(["d3", "./CommonND", "../common/HTMLWidget", "goog!visualization,1.1,packages:[scatter]"], factory);
     } else {
         root.google_Scatter = factory(root.d3, root.google_CommonND, root.common_HTMLWidget);
     }


### PR DESCRIPTION
I think material chart needs core charts to be fully loaded before its loaded.
While this fix appears to work, I am not sure why the corechart in the base CommonND is not being loaded first.

Fixes GH-995

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>