### PR TITLE
GH-980 Sets paletteID before C3 common update

### DIFF
--- a/src/c3chart/CommonND.js
+++ b/src/c3chart/CommonND.js
@@ -117,12 +117,12 @@
     };
 
     CommonND.prototype.update = function (domNode, element) {
-        Common.prototype.update.apply(this, arguments);
-
         this._palette = this._palette.switch(this.paletteID());
         if (this.useClonedPalette()) {
             this._palette = this._palette.cloneNotExists(this.paletteID() + "_" + this.id());
         }
+        
+        Common.prototype.update.apply(this, arguments);
 
         this.c3Chart.internal.config.axis_y_tick_format = d3.format(this.yAxisTickFormat());
 


### PR DESCRIPTION
Fixes GH-980

@GordonSmith @mlzummo @dtsnell4 Please Review

All C3 charts should now appropriately change color when the paletteID is changed (not requiring multiple updates before displaying the color change).

http://rawgit.com/jbrundage/Visualization/GH-980-C3ChartColors/demos/dermatology.html?src/c3chart/Line


Signed-off-by: Jay Brundage <jaman.brundage@lexisnexis.com>