### PR TITLE
GH-1127 Google Stacked Property

### DIFF
--- a/src/google/Area.js
+++ b/src/google/Area.js
@@ -105,7 +105,7 @@
         retVal.selectionMode = this.selectionMode();
         retVal.dataOpacity = this.dataOpacity();
 
-        retVal.stacked = this.stacked();
+        retVal.isStacked = this.stacked();
         retVal.areaOpacity = this.fillOpacity();
 
         retVal.hAxis = {};

--- a/src/google/Bar.js
+++ b/src/google/Bar.js
@@ -93,7 +93,7 @@
         var retVal = CommonND.prototype.getChartOptions.apply(this, arguments);
 
         retVal.dataOpacity = this.dataOpacity();
-        retVal.stacked = this.stacked();
+        retVal.isStacked = this.stacked();
         retVal.bar = {
             groupWidth: this.groupWidth()
         };

--- a/src/google/Column.js
+++ b/src/google/Column.js
@@ -94,7 +94,7 @@
         var retVal = CommonND.prototype.getChartOptions.apply(this, arguments);
 
         retVal.dataOpacity = this.dataOpacity();
-        retVal.stacked = this.stacked();
+        retVal.isStacked = this.stacked();
         retVal.bar = {
             groupWidth: this.groupWidth()
         };


### PR DESCRIPTION
Area, Bar and Column charts were incorrectly returning a "stacked" property to the Google chart.  This property is actually called "isStacked".

The HPCC publish parameter remains "stacked"

Fixes GH-1127

Signed-off-by: Dan Snell <Dan.Snell@lexisnexis.com>