### PR TITLE
GH-1175 Refactor Table Widget

### DIFF
--- a/src/composite/MegaChart.js
+++ b/src/composite/MegaChart.js
@@ -52,7 +52,7 @@
         
         this._layout.setContent("center", this._chart.chartType(this.chartType()));
         
-        this._layout.setContent("right", new Legend().targetWidget(this._layout.getContent("center")));
+        this._layout.setContent("right", new Legend().fixedSize(true).targetWidget(this._layout.getContent("center")));
         
         this._layout.setContent("bottom", this._valueTitle.rotation(-90));
         this._layout.setContent("left", this._domainTitle);
@@ -80,7 +80,7 @@
         }
         
         if(this.showLegend()){
-            this._layout.setContent("right", new Legend().targetWidget(this._layout.getContent("center")));
+            this._layout.setContent("right", new Legend().fixedSize(true).targetWidget(this._layout.getContent("center")));
         } else {
             this._layout.clearContent("right");
         }

--- a/src/other/Table.css
+++ b/src/other/Table.css
@@ -20,6 +20,7 @@
     color:white;
     white-space: nowrap;
     cursor : pointer;
+    box-sizing: border-box;
 }
 .other_Table thead > tr, .cols-wrapper tr {
     background-color:#1f77b4;
@@ -39,12 +40,12 @@
     background-color: white;
     color:black;
 }
-
-.other_Table .tableDiv tbody > tr:hover  {
+/*
+.other_Table .tableDiv tbody > tr:hover {
     background-color:#bfd7e7;
     color: white;
 }
-
+*/
 .other_Table .tableDiv tbody > tr.selected  {
     background-color:#f48a00;
     color: white;
@@ -63,10 +64,14 @@
     color: white;
 }
 
-.other_Table tbody > tr:hover, .other_Table tbody > tr.hover, .rows-wrapper tbody tr.hover {
+.other_Table .tableDiv tbody > tr:hover, .other_Table .tableDiv tbody > tr.hover, .rows-wrapper tbody tr.hover {
     background-color: #bfd7e7;
+    color: white;
 }
-
+.other_Table .tableDiv tbody > tr.selected:hover, .other_Table .tableDiv tbody > tr.selected.hover {
+    background-color: #5ea8db;
+    color: white;
+}
 .other_Table .rows-wrapper tbody tr.hover.selected {
     background-color:#5ea8db;
     color: white;
@@ -89,5 +94,4 @@
 .other_Table tfoot td, .rows-wrapper tfoot td {
     background-color: #ADDFF3;
     font-weight: bold;
-    border-top-width: 3px
 }

--- a/test/otherFactory.js
+++ b/test/otherFactory.js
@@ -116,6 +116,15 @@
                     );
                 });
             },
+            large: function (callback) {
+                require(["test/DataFactory", "src/other/Table"], function (DataFactory, Table) {
+                    callback(new Table()
+                    .columns(DataFactory.Table.large.columns)
+                    .data(DataFactory.Table.large.data)
+                    .fixedHeader(true)
+                    );
+                });
+            },
             totalled: function (callback) {
                 require(["test/DataFactory", "src/other/Table"], function (DataFactory, Table) {
                     callback(new Table()
@@ -123,6 +132,7 @@
                         .data(DataFactory.Table.large.data)
                         .totalledColumns([1,2,5,6,7])
                         .totalledLabel("Total")
+                        .columnPatterns(["", "", ".6r", "", "", "", "", "", "", "", ""])
                     );
                 });
             },
@@ -132,15 +142,6 @@
                         .columns(DataFactory.Table.formatted.columns)
                         .data(DataFactory.Table.formatted.data)
                         .columnPatterns([".4%", "", ".6r", "", "%d-%m-%y"])
-                    );
-                });
-            },
-            large: function (callback) {
-                require(["test/DataFactory", "src/other/Table"], function (DataFactory, Table) {
-                    callback(new Table()
-                    .columns(DataFactory.Table.large.columns)
-                    .data(DataFactory.Table.large.data)
-                    .fixedHeader(true)
                     );
                 });
             }


### PR DESCRIPTION
Refactors Table Widget to remove all copying javascript for the fixed header and first column. Makes widget all d3js.  Adds code to deselect a selected row(s) in the table.  Adds paginationLimit() publish parameter to automatically turn on pagination when a developer-defined number of rows is reached.

Fixes GH-1140
Fixes GH-1175
Fixes GH-1176

Signed-off-by: Dan Snell <Dan.Snell@lexisnexis.com>