### PR TITLE
Tweaks for HPCC ECL Watch

### DIFF
--- a/src/common/Shape.js
+++ b/src/common/Shape.js
@@ -18,7 +18,8 @@
     Shape.prototype.publish("height", 24, "number", "Height",null,{tags:["Private"]});
     Shape.prototype.publish("colorStroke", null, "html-color", "Stroke Color", null, {tags:["Private"]});
     Shape.prototype.publish("colorFill", null, "html-color", "Fill Color", null, {tags:["Private"]});
-    Shape.prototype.publish("radius", null, "number", "Radius",null,{tags:["Private"]});
+    Shape.prototype.publish("radius", null, "number", "Radius", null, { tags: ["Private"] });
+    Shape.prototype.publish("tooltip", "", "string", "Tooltip", null, { tags: ["Private"] });
 
     Shape.prototype._origRadius = Shape.prototype.radius;
     Shape.prototype.radius = function (_) {
@@ -42,47 +43,53 @@
     Shape.prototype.update = function (domNode, element) {
         var shape = element.selectAll("rect,circle,ellipse").data([this.shape()], function (d) { return d; });
 
+        var context = this;
         shape.enter().append(this.shape() === "square" ? "rect" : this.shape())
             .attr("class", "common_Shape")
-        ;
-        var context = this;
-        shape
-            .attr("fill", context.colorFill())
-            .attr("stroke", context.colorStroke())
             .each(function (d) {
-            var element = d3.select(this);
-            switch (context.shape()) {
-                case "circle":
-                    var radius = context.radius();
-                    element
-                        .attr("r", radius)
-                    ;
-                    break;
-                case "square":
-                    var width = Math.max(context.width(), context.height());
-                    element
-                        .attr("x", -width / 2)
-                        .attr("y", -width / 2)
-                        .attr("width", width)
-                        .attr("height", width)
-                    ;
-                    break;
-                case "rect":
-                    element
-                        .attr("x", -context.width() / 2)
-                        .attr("y", -context.height() / 2)
-                        .attr("width", context.width())
-                        .attr("height", context.height())
-                    ;
-                    break;
-                case "ellipse":
-                    element
-                        .attr("rx", context.width() / 2)
-                        .attr("ry", context.height() / 2)
-                    ;
-                    break;
-            }
-        });
+                var element = d3.select(this);
+                context._tooltipElement = element.append("title");
+            })
+        ;
+        shape
+            .style("fill", context.colorFill())
+            .style("stroke", context.colorStroke())
+            .each(function (d) {
+                var element = d3.select(this);
+                context._tooltipElement.text(context.tooltip());
+                switch (context.shape()) {
+                    case "circle":
+                        var radius = context.radius();
+                        element
+                            .attr("r", radius)
+                        ;
+                        break;
+                    case "square":
+                        var width = Math.max(context.width(), context.height());
+                        element
+                            .attr("x", -width / 2)
+                            .attr("y", -width / 2)
+                            .attr("width", width)
+                            .attr("height", width)
+                        ;
+                        break;
+                    case "rect":
+                        element
+                            .attr("x", -context.width() / 2)
+                            .attr("y", -context.height() / 2)
+                            .attr("width", context.width())
+                            .attr("height", context.height())
+                        ;
+                        break;
+                    case "ellipse":
+                        element
+                            .attr("rx", context.width() / 2)
+                            .attr("ry", context.height() / 2)
+                        ;
+                        break;
+                }
+            })
+        ;
         shape.exit().remove();
     };
 

--- a/src/common/Text.js
+++ b/src/common/Text.js
@@ -14,7 +14,7 @@
     Text.prototype._class += " common_Text";
 
     Text.prototype.publish("text", "", "string", "Display Text",null,{tags:["Basic"]});
-    Text.prototype.publish("fontFamily", "", "string", "Font Family",null,{tags:["Intermediate"]});
+    Text.prototype.publish("fontFamily", null, "string", "Font Family", null, { tags: ["Intermediate"], optional: true});
     Text.prototype.publish("fontSize", null, "number", "Font Size (px)", null, { tags: ["Intermediate"] });
     Text.prototype.publish("anchor", "middle", "set", "Anchor Position", ["start", "middle", "end"], { tags: ["Intermediate"] });
     Text.prototype.publish("colorFill", null, "html-color", "Fill Color", null, { tags: ["Basic"] });
@@ -34,7 +34,7 @@
             .attr("font-size", this.fontSize())
         ;
         var textParts = this.text().split("\n");
-        var textLine = this._textElement.selectAll("tspan").data(textParts, function (d) { return d; });
+        var textLine = this._textElement.selectAll("tspan").data(textParts);
         textLine.enter().append("tspan")
             .attr("class", function (d, i) { return "tspan_" + i; })
             .attr("dy", "1em")

--- a/src/common/TextBox.js
+++ b/src/common/TextBox.js
@@ -29,6 +29,8 @@
     TextBox.prototype.publishProxy("anchor", "_text");
     TextBox.prototype.publish("fixedSize", null);
 
+    TextBox.prototype.publish("tooltip", "", "string", "Tooltip", null, { tags: ["Private"] });
+
     TextBox.prototype.padding = function (_) {
         this.paddingLeft(_);
         this.paddingRight(_);
@@ -39,6 +41,7 @@
 
     TextBox.prototype.enter = function (domNode, element) {
         SVGWidget.prototype.enter.apply(this, arguments);
+        this._tooltipElement = element.append("title");
         this._shape
             .target(domNode)
             .render()
@@ -51,7 +54,7 @@
 
     TextBox.prototype.update = function (domNode, element) {
         SVGWidget.prototype.update.apply(this, arguments);
-
+        this._tooltipElement.text(this.tooltip());
         this._text
             .render()
         ;

--- a/src/graph/Edge.css
+++ b/src/graph/Edge.css
@@ -10,7 +10,7 @@
 }
 
 .graph_Edge .common_TextBox .common_Shape {
-    fill: none;
+    fill: white;
     stroke: none;
 }
 

--- a/src/graph/Edge.js
+++ b/src/graph/Edge.js
@@ -23,6 +23,7 @@
     Edge.prototype._class += " graph_Edge";
 
     Edge.prototype.publish("arcDepth", 16, "number", "Arc Depth", null, { tags: ["Basic"] });
+    Edge.prototype.publish("tooltip", "", "string", "Tooltip", null, { tags: ["Private"] });
 
     Edge.prototype.sourceVertex = function (_) {
         if (!arguments.length) return this._sourceVertex;
@@ -84,6 +85,7 @@
     Edge.prototype.enter = function (domNode, element) {
         SVGWidget.prototype.enter.apply(this, arguments);
         this._elementPath = element.append("path");
+        this._tooltipElement = this._elementPath.append("title");
 
         if (this._sourceMarker) {
             this._elementPath.attr("marker-start", "url(#" + this._sourceMarker + ")");
@@ -94,6 +96,7 @@
         if (this._textBox.text()) {
             this._textBox
                 .target(domNode)
+                .tooltip(this.tooltip())
                 .render()
             ;
         }
@@ -102,8 +105,6 @@
     Edge.prototype.update = function (domNode, element, transitionDuration, skipPushMarkers) {
         SVGWidget.prototype.update.apply(this, arguments);
         var context = this;
-        var pathElements = this._elementPath;
-
         if (this.svgMarkerGlitch && !skipPushMarkers) {
             element.transition().duration((transitionDuration ? transitionDuration : 0) + 100)
                 .each("start", function (d) {
@@ -136,6 +137,7 @@
                         points[2].x + "," +
                         points[2].y;
         }
+        var pathElements = this._elementPath;
         if (transitionDuration) {
             pathElements = pathElements.transition().duration(transitionDuration);
         }
@@ -144,9 +146,11 @@
             .attr("stroke-dasharray", this._strokeDasharray)
             .attr("d", line)
         ;
+        this._tooltipElement.text(this.tooltip());
 
         if (this._textBox.text()) {
             this._textBox
+                .tooltip(this.tooltip())
                 .move(this._findMidPoint(points), transitionDuration)
             ;
         }

--- a/src/graph/Graph.css
+++ b/src/graph/Graph.css
@@ -17,3 +17,11 @@
 .graph_Graph .graphVertex .graph_Vertex.selected .common_Shape {
     stroke:red !important;
 }
+
+.graph_Graph .graphEdge .graph_Edge.selected {
+    stroke:red !important;
+}
+
+.graph_Graph .graphEdge .graph_Edge.selected .common_Text {
+    fill:red !important;
+}

--- a/src/graph/Graph.js
+++ b/src/graph/Graph.js
@@ -122,7 +122,7 @@
     };
 
     Graph.prototype.applyZoom = function (transitionDuration) {
-        if (d3.event && d3.event.sourceEvent && !d3.event.sourceEvent.ctrlKey && (d3.event.sourceEvent.type === "wheel" || d3.event.sourceEvent.type === "mousewheel" || d3.event.sourceEvent.type === "DOMMouseScroll")) {
+        if (d3.event && d3.event.sourceEvent && d3.event.sourceEvent.ctrlKey && (d3.event.sourceEvent.type === "wheel" || d3.event.sourceEvent.type === "mousewheel" || d3.event.sourceEvent.type === "DOMMouseScroll")) {
             if (d3.event.sourceEvent.wheelDelta) {
                 this.zoom.translate([this.prevTranslate[0], this.prevTranslate[1] + d3.event.sourceEvent.wheelDelta]);
                 this.zoom.scale(this.prevScale);
@@ -554,10 +554,13 @@
             }
         }
 
-        var edgeElements = this.svgE.selectAll("#" + this._id + "E > .edge").data(this.showEdges() ? this.graphData.edgeValues() : [], function (d) { return d.id(); });
+        var edgeElements = this.svgE.selectAll("#" + this._id + "E > .graphEdge").data(this.showEdges() ? this.graphData.edgeValues() : [], function (d) { return d.id(); });
         edgeElements.enter().append("g")
-            .attr("class", "edge")
+            .attr("class", "graphEdge")
             .style("opacity", 1e-6)
+            .on("click.selectionBag", function (d) {
+                context._selection.click(d, d3.event);
+            })
             .on("click", function (d) {
                 context.edge_click(d);
             })
@@ -703,7 +706,7 @@
 
     Graph.prototype.highlightEdges = function (edgeMap) {
         var context = this;
-        var edgeElements = this.svgE.selectAll(".edge");
+        var edgeElements = this.svgE.selectAll(".graphEdge");
         edgeElements
             .style("stroke-width", function (o) {
                 if (edgeMap && edgeMap[o.id()]) {

--- a/src/graph/Vertex.js
+++ b/src/graph/Vertex.js
@@ -28,6 +28,8 @@
     Vertex.prototype.publishProxy("textbox_shape_colorFill", "_textBox", "shape_colorFill");
     Vertex.prototype.publishProxy("textbox_text_colorFill", "_textBox", "text_colorFill");
 
+    Vertex.prototype.publish("tooltip", "", "string", "Tooltip", null, { tags: ["Private"] });
+
     Vertex.prototype.publish("annotationDiameter", 14, "number", "Annotation Diameter",null,{tags:["Private"]});
     Vertex.prototype.publish("annotationSpacing", 3, "number", "Annotation Spacing",null,{tags:["Private"]});
     Vertex.prototype.publish("annotationIcons", [], "array", "Annotations",null,{tags:["Private"]});
@@ -47,9 +49,15 @@
 
     Vertex.prototype.update = function (domNode, element) {
         SVGWidget.prototype.update.apply(this, arguments);
-        this._icon.render();
+        this._icon
+            .tooltip(this.tooltip())
+            .render()
+        ;
         var iconClientSize = this._icon.getBBox(true);
-        this._textBox.render();
+        this._textBox
+            .tooltip(this.tooltip())
+            .render()
+        ;
         var bbox = this._textBox.getBBox(true);
         this._icon
             .move({ x: -(bbox.width / 2) + (iconClientSize.width / 3), y: -(bbox.height / 2) - (iconClientSize.height / 3) })


### PR DESCRIPTION
Text Widget would not show duplicate lines.
Text Widget would not maintain correct order.
Added tooltip support to:
* Shape, TextBox, Vertex, Edge

Added selection support for edges.
Reversed scroll wheel and ctrl+scroll wheel behaviour.

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>