### PR TITLE
GH-1005 Export Option on Table Widget

### DIFF
--- a/src/common/Utility.js
+++ b/src/common/Utility.js
@@ -237,6 +237,53 @@
                     return node;
                 }
             };
+        },
+        downloadData: function (format, data, id) {
+            id = id || "data";
+            var currentdate = new Date(); 
+            var timeFormat =  d3.time.format("%Y-%m-%dT%H_%M_%S");
+            var now = timeFormat(currentdate);
+
+            var filename = id + "_" + now + "." + format.toLowerCase();
+            
+            var mimeType = "";
+            switch (format) {
+                case "TSV":
+                    mimeType = "text/tab-seperated-values";
+                    break;
+                case "JSON":
+                    mimeType = "application/json";
+                    break;
+                default:
+                    mimeType = "text/csv";
+            }
+
+            var a = document.createElement('a');
+            if (navigator.msSaveBlob) { // IE10+
+                a = null;
+                return navigator.msSaveBlob(new Blob([data], { type: mimeType }), filename);
+            } else if ('download' in a) { //html 5
+                a.href = 'data:' + mimeType + ',' + encodeURIComponent(data);
+                a.setAttribute('download', filename);
+                document.body.appendChild(a);
+                setTimeout(function() {
+                    a.click();
+                    document.body.removeChild(a);
+                }, 10);
+                return true;
+            } else { //old chrome and FF:
+                a = null;
+                var frame = document.createElement('iframe');
+                document.body.appendChild(frame);
+                frame.src = 'data:' + mimeType + ',' + encodeURIComponent(data);
+
+                setTimeout(function() {
+                    document.body.removeChild(frame);
+                }, 100);
+                return true;
+            }
+
+            return false;
         }
 
     };

--- a/src/common/Widget.js
+++ b/src/common/Widget.js
@@ -47,6 +47,21 @@
     Widget.prototype.mixin(Platform);
     Widget.prototype.mixin(PropertyExt);
 
+    Widget.prototype.export = function (_) {
+        var formattedData;
+        switch(_) {
+            case "TSV":
+                formattedData = this._db.tsv();
+                break;
+            case "JSON":
+                formattedData = this._db.json();
+                break;
+            default:
+                formattedData = this._db.csv();
+        }
+        return formattedData;
+    };
+
     Widget.prototype.leakCheck = function (newNode) {
         var context = this;
         var watchArray = [newNode];

--- a/src/layout/Surface.css
+++ b/src/layout/Surface.css
@@ -7,8 +7,6 @@
 .layout_Surface > h3 {
     margin: 0px;
     padding: 2px;
-    text-align: center;
-    font-weight: bold;
     background-color: #e5e5e5;
 }
 .layout_Surface .html-button-container {
@@ -22,11 +20,11 @@
 }
 
 .layout_Surface .html-button-container .surface-button {
-    position: relative;
-    background: transparent;
-    border: none;
+    margin-right: 5px;
+}
+.layout_Surface .html-button-container .surface-button i {
     opacity: 0.8;
-}​
+}
 
 .layout_Surface .html-button-container .surface-button:hover { opacity: 1; }
 .layout_Surface .html-button-container .surface-button:active { opacity: 0.5; }

--- a/src/layout/Surface.js
+++ b/src/layout/Surface.js
@@ -93,14 +93,16 @@
                     .style("cursor","pointer");
                 if (button.font === "FontAwesome") {
                     el
-                      .on("click", function(d) { context.click(d); })
-                      .append("i")
-                      .attr("class","fa")
-                      .text(function(d) { return button.label; });
+                        .style("background", "transparent")
+                        .style("border", "none")
+                        .on("click", function(d) { context.click(d); })
+                        .append("i")
+                        .attr("class","fa")
+                        .text(function(d) { return button.label; });
                 } else {
                     el
-                      .text(function(d) { return button.label; })
-                      .on("click", function(d) { context.click(d); });
+                        .text(function(d) { return button.label; })
+                        .on("click", function(d) { context.click(d); });
                 }
             })
         ;

--- a/test/DataFactory.js
+++ b/test/DataFactory.js
@@ -302,7 +302,7 @@
             simple: {
                 title: ["Hello and welcome!"],
                 menu: ["aaa", "bbb", "ccc"],
-                buttonAnnotations: [{id:"button_1",label:"\uf010",shape:"square",diameter:14,padding:"0px 5px",font:"FontAwesome"}, {id:"button_2",label:"\uf00e",shape:"square",diameter:14,padding:"0px 5px",font:"FontAwesome"}],
+                buttonAnnotations: [{id:"button_1",label:"\uf010",shape:"square",diameter:14,padding:"0px 5px",font:"FontAwesome"}, {id:"button_2",label:"\uf00e",shape:"square",diameter:14,padding:"0px 5px",font:"FontAwesome"}]
             }
         },
         AbsoluteSurface: {

--- a/test/commonFactory.js
+++ b/test/commonFactory.js
@@ -151,6 +151,30 @@
                         });
                     });
             }
+        },
+        Exporter: {
+            Simple: function (callback) {
+                require(["test/DataFactory", "src/layout/Surface", "src/chart/Line", "src/common/Utility"], function (DataFactory, Surface, Line, Utility) {
+                    var retVal = new Surface()
+                        .title(DataFactory.Surface.simple.title)
+                        .buttonAnnotations([{id:"export_CSV",label:"CSV",width:"50px", height:"18px",padding:"0px 5px", format:"CSV"},
+                            {id:"export_TSV",label:"TSV",width:"50px", height:"18px",padding:"0px 5px", format:"TSV"},
+                            {id:"export_CSV",label:"JSON",width:"50px", height:"18px",padding:"0px 5px", format:"JSON"}])
+                        .widget(new Line()
+                            .columns(DataFactory.ND.subjects.columns)
+                            .data(DataFactory.ND.subjects.data)
+                        )
+                        .on("click", function(d) {
+                            var formattedData = retVal.widget().export(d.format);
+                            var classID = retVal.widget().classID();
+                            if (confirm("The data in " + d.format + " format:\n\n" + formattedData + "\n\n Would you like to save it as a file?")) {
+                                Utility.downloadData(d.format, formattedData, classID);
+                            }
+                        })
+                    ;
+                    callback(retVal);
+                });
+            }
         }
     };
 


### PR DESCRIPTION
Adds an Exporter widget so that  any widget can export its data to CSV, TSV, or JSON formats, and save as a file.

Fixes GH-1005

Signed-off-by: Dan Snell <Dan.Snell@lexisnexis.com>