### PR TITLE
GH-1195 Popup Layout needs shrink to fit option

### DIFF
--- a/src/layout/Popup.js
+++ b/src/layout/Popup.js
@@ -17,48 +17,70 @@
     Popup.prototype._class += " layout_Popup";
     
     Popup.prototype.publish("popupState", false, "boolean", "State of the popup, visible (true) or hidden (false)",null,{});
+    Popup.prototype.publish("shrinkWrap", false, "boolean", "The popup parent container either shrinks to the size of its contents (true) or expands to fit thge popup's parentDiv (false)",null,{});
+    Popup.prototype.publish("centerPopup", "none", "set", "Center the widget in its container element (target) or in the window",["none", "container", "window"],{});
     Popup.prototype.publish("top", null, "number", "Top position property of popup",null,{});
     Popup.prototype.publish("bottom", null, "number", "Bottom position property of popup",null,{});
     Popup.prototype.publish("left", null, "number", "Left position property of popup",null,{});
     Popup.prototype.publish("right", null, "number", "Right position property of popup",null,{});
     Popup.prototype.publish("position", "relative", "set", "Value of the 'position' property",["absolute", "relative", "fixed", "static", "initial", "inherit" ],{tags:["Private"]});
+
     Popup.prototype.publish("widget", null, "widget", "Widget",null,{tags:["Private"]});
 
-    Popup.prototype.widgetSize = function (widgetDiv) {
-        var width = this.clientWidth() - this.calcFrameWidth(widgetDiv);
-        var height = this.clientHeight() - this.calcFrameHeight(widgetDiv);
- 
-        return { width: width, height: height };
-    };
-    
     Popup.prototype.updateState = function (visible) {
-            this.popupState(visible).render();
+        visible  = visible || !this.popupState();
+        this.popupState(visible).render();
     };
+
+    Popup.prototype.enter = function (domNode, element) {
+        HTMLWidget.prototype.enter.apply(this, arguments);
+        this.widget()
+            .target(domNode)
+        ;       
+        this._originalPosition = this.position();
+    };    
 
     Popup.prototype.update = function (domNode, element) {
         HTMLWidget.prototype.update.apply(this, arguments);
-        var context = this;        
-
-        this.visible(this.popupState());
-        
-        var widgets = element.selectAll("#" + this._id + " > .popupWidget").data(this.widget() ? [this.widget()] : [], function (d) { return d._id; });
-        widgets.enter().append("div")
-            .attr("class", "popupWidget")
-            .each(function (d) {
-                d.target(this);
-            })
-        ;
-        widgets
-            .each(function (d) {
-                var widgetSize = context.widgetSize(d3.select(this));
-                d.resize({ width: widgetSize.width, height: widgetSize.height });
-            })
-        ;
-        widgets.exit().each(function (d) {
-            d.target(null);
-        }).remove();
+        element.style({
+            visibility: this.popupState() ? null : "hidden",
+            opacity: this.popupState() ? null : 0,
+            width: this.shrinkWrap() ? this.widget().width() + "px": this._size.width + "px",
+            height: this.shrinkWrap() ? this.widget().height() + "px" : this._size.height + "px",
+        });
+        if (this.widget().size().height === 0 ) {
+            this.widget().resize(this.size());
+        }
     };
+
     Popup.prototype.postUpdate = function (domNode, element) {
+        var left, top; 
+        switch (this.centerPopup()) {
+            case "container":
+                if (this._parentElement) {
+                    left = parseInt(this._parentElement.style("width"))/2 - this.widget().width()/2;
+                    top = parseInt(this._parentElement.style("height"))/2 - this.widget().height()/2;
+                }
+                this.position("absolute");
+                break;
+
+            case "window":
+                left = window.innerWidth/2 - this.widget().width()/2;
+                top = window.innerHeight/2 - this.widget().height()/2;
+                this.position("fixed");
+                break;
+
+            default:
+                left = 0;
+                top = 0;
+                this.position(this._originalPosition);
+                break;
+        } 
+
+        this.pos({ x: left, y: top });
+        
+        HTMLWidget.prototype.postUpdate.apply(this, arguments);
+        
         element
             .style("position",this.position())
             .style("left",this.left() + "px")

--- a/test/layoutFactory.js
+++ b/test/layoutFactory.js
@@ -211,6 +211,38 @@
 
                     callback(retVal);
                 });
+            },
+            shrink: function (callback) {
+                require(["test/DataFactory", "src/layout/Popup", "src/layout/Surface", "src/other/Table"], function (DataFactory, Popup, Surface, Table) {
+                    var retVal =  new Popup();
+
+                    retVal
+                        .widget(new Table()
+                            .columns(DataFactory.Table.simple.columns)
+                            .data(DataFactory.Table.simple.data)
+                            .fixedSize(true)
+                        )
+                        .shrinkWrap(true)
+                    ;
+
+                    callback(retVal);
+                });
+            },
+            shrink2: function (callback) {
+                require(["test/DataFactory", "src/layout/Popup", "src/layout/Surface", "src/chart/Line"], function (DataFactory, Popup, Surface, Line) {
+                    var retVal =  new Popup();
+
+                    retVal
+                        .widget(new Line()
+                            .columns(DataFactory.ND.subjects.columns)
+                            .data(DataFactory.ND.subjects.data)
+                            .size({width: 500, height:400})
+                        )
+                        .shrinkWrap(true)
+                    ;
+
+                    callback(retVal);
+                });
             }
         },
         Surface: {


### PR DESCRIPTION
Adds shrinkWrap() parameter that resizes the popup around its content widget if it has an explicit size.
Also adds the centerPopup() parameter which will center the popup in its container, or in the window.

Fixes GH-1195

Signed-off-by: Dan Snell <Dan.Snell@lexisnexis.com>