### PR TITLE
GH-1370 MegaChart missing click handler

### DIFF
--- a/src/composite/MegaChart.js
+++ b/src/composite/MegaChart.js
@@ -152,5 +152,10 @@
         return obj;
     };
 
+    //  Events  ---
+    MegaChart.prototype.click = function (row, column, selected) {
+        console.log("Click:  " + JSON.stringify(row) + ", " + column + ", " + selected);
+    };
+
     return MegaChart;
 }));


### PR DESCRIPTION
The marshaller won't attach a click handler, if the chart does not have a default one already.

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>