### PR TITLE
GH-1399 C3Charts can corrupt

### DIFF
--- a/src/c3chart/Common.js
+++ b/src/c3chart/Common.js
@@ -26,6 +26,8 @@
         this._config.data.onclick = function (d, element) {
             context.click(context.rowToObj(context.data()[d.index]), d.id, context.c3Chart.selected().length > 0);
         };
+
+        this._renderPromise = Promise.resolve();
     }
     Common.prototype = Object.create(HTMLWidget.prototype);
     Common.prototype.constructor = Common;
@@ -43,7 +45,7 @@
     Common.prototype.publish("fontColor", null, "html-color", "Font Color",null,{tags:["Basic","Shared"]});
 
     Common.prototype.publish("legendPosition", "right", "set", "Legend Position", ["bottom", "right"],{tags:["Intermediate"]});
-    Common.prototype.publish("animationDuration", 0, "number", "Animation Duration",null,{tags:["Advanced"]});
+    Common.prototype.publish("animationDuration", 350, "number", "Animation Duration",null,{tags:["Advanced"]});
 
     Common.prototype.type = function (_) {
         if (!arguments.length) return this._type;
@@ -153,6 +155,23 @@
                     "font-style": this.legendFontItalic() ? "italic" : "normal"
                 })
                 .attr("font-family",this.legendFontFamily());
+    };
+
+    var timeBuffer = 400; //  C3 Tranistion default is 350, legend transition cannot be changed...  ---
+    Common.prototype.render = function (callback) {
+        var context = this;
+        this._renderPromise = this._renderPromise.then(function() {
+            return new Promise(function (resolve, reject) {
+                HTMLWidget.prototype.render.call(context, function (w) {
+                    setTimeout(function () {
+                        if (callback) {
+                            callback(w);
+                        }
+                        resolve();
+                    }, Math.max(timeBuffer, context.animationDuration()));
+                });
+            });
+        });
     };
 
     Common.prototype.getChartOptions = function () {

--- a/test/c3chartFactory.js
+++ b/test/c3chartFactory.js
@@ -132,6 +132,64 @@
                     .data(DataFactory.TwoD.subjects.data)
                     );
                 });
+            },
+            changingData: function (callback) {
+                require(["test/DataFactory", "src/c3chart/Pie"], function (DataFactory, Pie) {
+                    var pie = new Pie()
+                        .columns(["Subject", "Year 1"])
+                        .data([
+                            ["Geog", 75],
+                            ["English", 45],
+                            ["Math", 98],
+                            ["Science", 66]
+                        ])
+                    ;
+                    callback(pie);
+                    var timeLapse = 100;
+                    setTimeout(function () {
+                        pie
+                            .columns(["Subject", "Year 1"])
+                            .data([
+                                ["Geog2", 75],
+                                ["English", 45],
+                                ["Math", 98],
+                                [, 66]
+                            ])
+                            .render()
+                        ;
+                        setTimeout(function () {
+                            pie
+                                .columns(["Subject", "Year 1"])
+                                .data([
+                                    ["Geog3", 75],
+                                    ["English", 45],
+                                    ["Math", 98],
+                                    ["Science", 66]
+                                ])
+                                .render()
+                            ;
+                            setTimeout(function () {
+                                pie
+                                    .columns(["Subject", "Year 1"])
+                                    .data([])
+                                    .render()
+                                ;
+                                setTimeout(function () {
+                                    pie
+                                        .columns(["Subject", "Year 1"])
+                                        .data([
+                                            ["Geog4", 75],
+                                            ["English2", 45],
+                                            ["Math", 98],
+                                            [, 66]
+                                        ])
+                                        .render()
+                                    ;
+                                }, timeLapse);
+                            }, timeLapse);
+                        }, timeLapse);
+                    }, timeLapse);
+                });
             }
         },
         Step: {


### PR DESCRIPTION
If render is called while the previous render is still "transitioning", then the corruption can occur.

Fixes GH-1399

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>