### PR TITLE
GH-1535 DDL sorts wrong column

### DIFF
--- a/src/common/PropertyExt.js
+++ b/src/common/PropertyExt.js
@@ -22,7 +22,7 @@
         this.id = id;
         this.type = type;
         this.origDefaultValue = defaultValue;
-        this.defaultValue = defaultValue;
+        this.defaultValue = defaultValue === null ? undefined : defaultValue;
         this.description = description;
         this.set = set;
         this.ext = ext || {};

--- a/src/marshaller/HipieDDL.js
+++ b/src/marshaller/HipieDDL.js
@@ -411,10 +411,11 @@
 
     Source.prototype.getData = function () {
         var db = this.getOutput().db;
-        var retVal = this.mappings.doMapAll(db);
-        if (retVal.length && this.sort) {
-            Utility.multiSort(retVal, db.hipieMapSortArray(this.sort));
+        var dataRef = db.data();
+        if (dataRef.length && this.sort) {
+            Utility.multiSort(dataRef, db.hipieMapSortArray(this.sort));
         }
+        var retVal = this.mappings.doMapAll(db);
         if (this.reverse) {
             retVal.reverse();
         }


### PR DESCRIPTION
Sort data before mapping it.
Force null to undefined for default optional properties.

Fixes GH-1535

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>