### PR TITLE
GH-1641 AM Charts + rawgit

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -165,6 +165,7 @@
     }
 
     function githubConfig(srcUrl) {
+        optimizerConfig(root.hpccsystems.require);
         return root.hpccsystems.require.config({
             waitSeconds: 30,
             baseUrl: ".",


### PR DESCRIPTION
am charts "shims" are not being called when hosted on rawgit.

Fixes GH-1641

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>