### PR TITLE
GH-1770 datasource.output.filter invalid

### DIFF
--- a/src/marshaller/HipieDDL.js
+++ b/src/marshaller/HipieDDL.js
@@ -1013,11 +1013,12 @@
             for (var oKey in this.outputs) {
                 var output = this.outputs[oKey];
                 output.notify.forEach(function (item) {
-                    if (!output.filter || !output.filter.length) {
-                        updates.push(item);
-                    }
                     var viz = this.dashboard.getVisualization(item);
-                    viz.update(loading);
+                    var inputs = viz.getInputVisualizations();
+                    if (!inputs.length) {
+                        updates.push(item);
+                        viz.update(loading);
+                    }
                 }, this);
             }
         }


### PR DESCRIPTION
Ignore datasource.output.filter for the purpose of initial render.

Fixes GH-1770

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>