### PR TITLE
Added title attribute to property editor rows

### DIFF
--- a/src/other/PropertyEditor.js
+++ b/src/other/PropertyEditor.js
@@ -339,6 +339,7 @@
         rows.each(function (param) {
             var tr = d3.select(this);
             tr.classed("disabled", d[param.id + "_disabled"] && d[param.id + "_disabled"]());
+            tr.attr("title", param.description);
             if (hasProperties(param.type)) {
                 context.updateWidgetRow(d, tr.select("td"), param);
             } else {


### PR DESCRIPTION
This allows tooltips to appear in the property editor, sourced from the property descriptions.