### PR TITLE
GH-1918 Default values ignored during primeData

### DIFF
--- a/src/marshaller/HipieDDL.js
+++ b/src/marshaller/HipieDDL.js
@@ -1533,7 +1533,10 @@
     Dashboard.prototype.primeData = function (state) {
         var fetchDataOptimizer = new VisualizationRequestOptimizer();
         this.getVisualizationArray().forEach(function (visualization) {
+            //  Clear all charts back to their default values ---
             visualization.clear();
+        });
+        this.getVisualizationArray().forEach(function (visualization) {
             if (state) {
                 if (state[visualization.id]) {
                     visualization.getUpdates().forEach(function (updateObj) {


### PR DESCRIPTION
Clear all visualization before calculating their default states

Fixes GH-1918

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>