### PR TITLE
GH-1932 Override default CDN host

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -273,6 +273,7 @@
 
     if (!root.hpccsystems.redirect) {
         root.hpccsystems.redirect = (function () {
+            var cdnHost = "viz.hpccsystems.com";
             function url(opts) {
                 opts = opts || {};
                 var protocol = opts.protocol || (root.location.protocol === "https:" ? "https:" : "http:");
@@ -286,13 +287,18 @@
 
             function cdnUrl(version) {
                 return url({
-                    hostname: "viz.hpccsystems.com",
+                    hostname: cdnHost,
                     port: "",
                     pathname: "/" + version + "/dist-amd"
                 });
             }
 
             return {
+                cdnHost: function(_) {
+                    if (!arguments.length) return cdnHost;
+                    cdnHost = _;
+                    return this;
+                },
                 github: function (branch, org, repo, callback) {
                     callback = arguments[arguments.length - 1];
                     switch (arguments.length) {

--- a/test/loader.js
+++ b/test/loader.js
@@ -32,6 +32,16 @@ define([], function (Loader) {
                 });
             });
         });
+        it("cdnAltHost", function (done) {
+            hpccsystems.redirect
+                .cdnHost("cdn.rawgit.com/hpcc-systems/Visualization")
+                .cdn("v1.14.0-rc10", function (require) {
+                    require(["src/common/Widget"], function (Widget) {
+                        assert.equal(Widget.prototype.classID(), "common_Widget");
+                        done();
+                    });
+                });
+        });
         it("comms", function (done) {
             require(["src/other/Comms"], function (Comms) {
                 assert.isNull(Comms.createESPConnection("xxxx"));


### PR DESCRIPTION
Add ability to replace viz.hpccsystems.com with an alternative source.

Fixes GH-1932

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>