### PR TITLE
GH-1963 locateParentWidget fails when _target is not set

### DIFF
--- a/src/common/Widget.js
+++ b/src/common/Widget.js
@@ -296,12 +296,14 @@
     };
 
     Widget.prototype.locateParentWidget = function (domNode) {
-        domNode = domNode || this._target.parentNode;
-        var widget = this.toWidget(domNode);
-        if (widget) {
-            return widget;
-        } else if (domNode.parentNode) {
-            return this.locateParentWidget(domNode.parentNode);
+        domNode = domNode || (this._target ? this._target.parentNode : null);
+        if (domNode) {
+            var widget = this.toWidget(domNode);
+            if (widget) {
+                return widget;
+            } else if (domNode.parentNode) {
+                return this.locateParentWidget(domNode.parentNode);
+            }
         }
         return null;
     };


### PR DESCRIPTION
Fixes GH-1963

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>