### PR TITLE
GH-1971 Propagate Clear Render Issue

### DIFF
--- a/src/marshaller/HipieDDL.js
+++ b/src/marshaller/HipieDDL.js
@@ -1097,6 +1097,11 @@
                     resolve();
                 });
             }
+            if (context.dashboard.marshaller.propogateClear()) {
+                context.events.getUpdatesVisualizations().forEach(function (updatedViz) {
+                    updatedViz.update();
+                });
+            }
         });
     };
 


### PR DESCRIPTION
Propagate clear needs a corresponding propagate update (otherwise the clear is not rendered).

Fixes GH-1971

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>