### PR TITLE
GH-2164 PrimeData Logic Priorities

### DIFF
--- a/src/marshaller/HipieDDL.js
+++ b/src/marshaller/HipieDDL.js
@@ -1642,16 +1642,17 @@
         this.getVisualizationArray().forEach(function (visualization) {
             var inputVisualizations = visualization.getInputVisualizations();
             var datasource = visualization.source.getDatasource();
-            if ((datasource && datasource.isRoxie()) || inputVisualizations.length === 0) {
+            var hasInputSelection = false;
+            inputVisualizations.forEach(function (inViz) {
+                if (inViz.hasSelection()) {
+                    var request = inViz.calcRequestFor(visualization);
+                    request.refresh = true;
+                    fetchDataOptimizer.appendRequest(datasource, request, visualization);
+                    hasInputSelection = true;
+                }
+            });
+            if (!hasInputSelection && ((datasource && datasource.isRoxie()) || inputVisualizations.length === 0)) {
                 fetchDataOptimizer.appendRequest(datasource, { refresh: true }, visualization);
-            } else {
-                inputVisualizations.forEach(function (inViz) {
-                    if (inViz.hasSelection()) {
-                        var request = inViz.calcRequestFor(visualization);
-                        request.refresh = true;
-                        fetchDataOptimizer.appendRequest(datasource, request, visualization);
-                    }
-                });
             }
         });
         return fetchDataOptimizer.fetchData();

--- a/test/marshallerFactory.js
+++ b/test/marshallerFactory.js
@@ -52,7 +52,7 @@
             wu: function (callback) {
                 require(["test/DataFactory", "src/marshaller/HTML"], function (DataFactory, HTML) {
                     callback(new HTML()
-                        .ddlUrl_default("http://10.241.100.159:8010/WsWorkunits/WUResult.json?Wuid=W20160822-142317&ResultName=SuspectAddressDemo_Comp_Ins011_DDL")
+                        .ddlUrl_default("http://10.241.100.159:8010/WsWorkunits/WUResult.json?Wuid=W20170220-163846&ResultName=overivewv0_Comp_Ins80933_DDL&SuppressXmlSchema=true")
                     );
                 });
             },


### PR DESCRIPTION
During initial load change logic to give preference over inputs with default values.
Then fallback to default call for roxie queries and widgets with no inputs.

Fixes GH-2164

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>