### PR TITLE
Amcharts serial: Formatter getting clobbered with multiple Y Axis

### DIFF
--- a/src/amchart/CommonSerial.js
+++ b/src/amchart/CommonSerial.js
@@ -345,7 +345,8 @@
         };
 
         for (var i = 0; i < this.yAxes().length; i++) {
-            var yAxis = this.yAxes()[i];
+            var valueFormatter,
+                yAxis = this.yAxes()[i];
             //yAxis.type("y");
 
             if (!this._chart.valueAxes[i]) {
@@ -379,18 +380,18 @@
                     this._chart.valueAxes[i].logarithmic = false;
 
                     if (yAxis.axisTickFormat()) {
-                        this.valueFormatter = d3.time.format(yAxis.axisTickFormat());
+                        valueFormatter = d3.time.format(yAxis.axisTickFormat());
                     } else if (yAxis.axisTypeTimePattern()) {
-                        this.valueFormatter = d3.time.format(yAxis.axisTypeTimePattern());
+                        valueFormatter = d3.time.format(yAxis.axisTypeTimePattern());
                     } else {
-                        this.valueFormatter =  function(v) { return v; };
+                        valueFormatter =  function(v) { return v; };
                     }
                     break;
                 case "log":
                     this._chart.valueAxes[i].parseDates = false;
                     this._chart.valueAxes[i].logarithmic = true;
                     this._chart.valueAxes[i].type = "numeric";
-                    this.valueFormatter = yAxis.axisTickFormat() ? d3.format(yAxis.axisTickFormat()) : function(v) { return v; };
+                    valueFormatter = yAxis.axisTickFormat() ? d3.format(yAxis.axisTickFormat()) : function(v) { return v; };
                     break;
                 case "linear":
                     /* falls through */
@@ -398,18 +399,20 @@
                     this._chart.valueAxes[i].parseDates = false;
                     this._chart.valueAxes[i].type = "numeric";
                     this._chart.valueAxes[i].logarithmic = false;
-                    this.valueFormatter = yAxis.axisTickFormat() ? d3.format(yAxis.axisTickFormat()) : function(v) { return v; };
+                    valueFormatter = yAxis.axisTickFormat() ? d3.format(yAxis.axisTickFormat()) : function(v) { return v; };
                     break;
             }
 
-            this._chart.valueAxes[i].labelFunction = function(v1, v2, v3) {
-                switch (yAxis.axisType()) {
-                    case "time":
-                        return context.valueFormatter(yAxis.axisTickFormat() || yAxis.axisTypeTimePattern() ? new Date(v2) : v2);
-                    default:
-                        return context.valueFormatter(v1);
+            this._chart.valueAxes[i].labelFunction = function(axis, formatter) {
+                return function(v1, v2, v3) {
+                    switch (axis.axisType()) {
+                        case "time":
+                            return formatter(axis.axisTickFormat() || axis.axisTypeTimePattern() ? new Date(v2) : v2);
+                        default:
+                            return formatter(v1);
+                    }
                 }
-            };
+            }(yAxis, valueFormatter);
         }
 
         if (this.showScrollbar()) {


### PR DESCRIPTION
There are two problems with how the custom formatting is done with the Y Axis in CommonSerial:

1. All formatters are being written to **this.valueFormatter**; 'this' being the chart object. Automatically, the X axis formatter will be clobbered by the Y axis formatter on a serial chart. If there are multiple Y axes, then the last one "wins".

2. While the labelFunction is an anonymous function accessing the yAxis via closure, the reference it is grabbing is always the **last Y axis**. For serial charts with more than one Y axis, earlier axes will be looking at the wrong data for formatting purposes. This was resolved by creating a wrapper that passes in the axis and formatter as parameters, to force a new closure.