### PR TITLE
GH-2372 Remove FA from common bundle

### DIFF
--- a/packages/common/src/FAChar.ts
+++ b/packages/common/src/FAChar.ts
@@ -1,7 +1,6 @@
 import { SVGWidget } from "./SVGWidget";
 import { Text } from "./Text";
 
-import "font-awesome/css/font-awesome.css";
 import "../src/FAChar.css";
 
 export class FAChar extends SVGWidget {


### PR DESCRIPTION
Since the fonts will get pulled relative to the host web page and not the
bundle, it can never work in a "prod" environment.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>