### PR TITLE
GH-2400 Fixes graphGraph centroid filter in IE10

### DIFF
--- a/src/graph/Graph.js
+++ b/src/graph/Graph.js
@@ -886,16 +886,32 @@
                 .attr("cy", 5)
                 .attr("r", 4)
             ;
-        this.defs.append("filter")
+        var filter = this.defs.append("filter")
             .attr("id", this._id + "_glow")
             .attr("width", "130%")
-            .attr("height", "130%")    
-            .html(
-                '<feOffset result="offOut" in="SourceGraphic" dx="0" dy="0"></feOffset>' +
-                '<feColorMatrix result="matrixOut" in="offOut" type="matrix" values="0.2 0 0 0 0 0 0.2 0 0 1 0 0 0.2 0 0 0 0 0 1 0" />' +
-                '<feGaussianBlur result="blurOut" in="matrixOut" stdDeviation="3"></feGaussianBlur>' +
-                '<feBlend in="SourceGraphic" in2="blurOut" mode="normal"></feBlend>'
-            )
+            .attr("height", "130%")
+            ;
+        filter.append('feOffset')
+            .attr("result", "offOut")
+            .attr("in", "SourceGraphic")
+            .attr("dx", "0")
+            .attr("dy", "0")
+            ;
+        filter.append('feColorMatrix')
+            .attr("result", "matrixOut")
+            .attr("in", "offOut")
+            .attr("type", "matrix")
+            .attr("values", "0.2 0 0 0 0 0 0.2 0 0 1 0 0 0.2 0 0 0 0 0 1 0")
+            ;
+        filter.append('feGaussianBlur')
+            .attr("result", "blurOut")
+            .attr("in", "matrixOut")
+            .attr("stdDeviation", "3")
+            ;
+        filter.append('feBlend')
+            .attr("in", "SourceGraphic")
+            .attr("in2", "blurOut")
+            .attr("mode", "normal")
             ;
     };
 


### PR DESCRIPTION
Evidently IE10 didn't like setting the contents of an svg filter element using `.html()`

Fixes GH-2400

@GordonSmith please review

Signed-off-by: Jay Brundage <jaman.brundage@lexisnexis.com>