### PR TITLE
GH-2426 layout/Layered SVG mouse events

### DIFF
--- a/packages/layout/src/Layered.css
+++ b/packages/layout/src/Layered.css
@@ -4,6 +4,7 @@
 .layout_Layered > .container > .content {
     position: absolute;
 }
-.layout_Layered > .container > .content > div > .common_Widget {
+.layout_Layered > .container > .content > div > .common_Widget,
+.layout_Layered > .container > .content > div > svg > .common_Widget {
     pointer-events: all;
 }


### PR DESCRIPTION
layout/Layered incorrectly disables SVG widget mouse events.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>