### PR TITLE
Publish

### DIFF
--- a/packages/amchart/package.json
+++ b/packages/amchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/amchart",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz AM Charts",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,8 +25,8 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "amcharts3": "amcharts/amcharts3#3.18.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/api",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz api",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,7 +25,7 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/c3chart/package.json
+++ b/packages/c3chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/c3chart",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "hpcc-js - Viz C3 Charts",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,8 +25,8 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "@hpcc-js/c3-shim": "^0.0.49",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/chart",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "hpcc-js - Viz Chart",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,9 +25,9 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/util": "^0.0.70"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/util": "^0.0.71"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/codemirror",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "hpcc-js - Viz Code Mirror",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,11 +25,11 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/dgrid": "^0.0.83",
-    "@hpcc-js/html": "^0.0.72",
-    "@hpcc-js/phosphor": "^0.0.75",
-    "@hpcc-js/util": "^0.0.70"
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/dgrid": "^0.0.84",
+    "@hpcc-js/html": "^0.0.73",
+    "@hpcc-js/phosphor": "^0.0.76",
+    "@hpcc-js/util": "^0.0.71"
   },
   "devDependencies": {
     "@hpcc-js/codemirror-shim": "^0.0.59",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/common",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz Common",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -27,7 +27,7 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/util": "^0.0.70"
+    "@hpcc-js/util": "^0.0.71"
   },
   "devDependencies": {
     "@types/d3-scale": "1",

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/comms",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "description": "hpcc-js - Communications",
   "main": "dist/index.node.js",
   "module": "dist/index.es6",
@@ -29,7 +29,7 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/util": "^0.0.70",
+    "@hpcc-js/util": "^0.0.71",
     "node-fetch": "2.0.0",
     "safe-buffer": "5.1.1",
     "semver": "5.5.0",

--- a/packages/composite/package.json
+++ b/packages/composite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/composite",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "description": "hpcc-js - Viz Composite",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,15 +25,15 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/chart": "^0.0.74",
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/dgrid": "^0.0.83",
-    "@hpcc-js/form": "^0.0.74",
-    "@hpcc-js/html": "^0.0.72",
-    "@hpcc-js/layout": "^0.0.72",
-    "@hpcc-js/other": "^0.0.72",
-    "@hpcc-js/phosphor": "^0.0.75"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/chart": "^0.0.75",
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/dgrid": "^0.0.84",
+    "@hpcc-js/form": "^0.0.75",
+    "@hpcc-js/html": "^0.0.73",
+    "@hpcc-js/layout": "^0.0.73",
+    "@hpcc-js/other": "^0.0.73",
+    "@hpcc-js/phosphor": "^0.0.76"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/dgrid/package.json
+++ b/packages/dgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/dgrid",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "description": "hpcc-js - Viz DGrid",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,9 +25,9 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72",
+    "@hpcc-js/common": "^0.0.73",
     "@hpcc-js/dgrid-shim": "^0.0.59",
-    "@hpcc-js/util": "^0.0.70"
+    "@hpcc-js/util": "^0.0.71"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/eclwatch/package.json
+++ b/packages/eclwatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/eclwatch",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "hpcc-js - ECL Watch",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,10 +25,10 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/comms": "^0.0.77",
-    "@hpcc-js/dgrid": "^0.0.83",
-    "@hpcc-js/util": "^0.0.70"
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/comms": "^0.0.78",
+    "@hpcc-js/dgrid": "^0.0.84",
+    "@hpcc-js/util": "^0.0.71"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/form",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "hpcc-js - Viz Form",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,9 +25,9 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/chart": "^0.0.74",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/chart": "^0.0.75",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/google",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz Google",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,8 +25,8 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/graph",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "hpcc-js - Viz Graph",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,8 +25,8 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/handson/package.json
+++ b/packages/handson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/handson",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz Handson Grid",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,7 +25,7 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/html",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz HTML",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,7 +25,7 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "@hpcc-js/preact-shim": "^0.0.56",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/layout",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz Layout",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,8 +25,8 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/map",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "description": "hpcc-js - Viz Map",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -26,11 +26,11 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/graph": "^0.0.73",
-    "@hpcc-js/layout": "^0.0.72",
-    "@hpcc-js/other": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/graph": "^0.0.74",
+    "@hpcc-js/layout": "^0.0.73",
+    "@hpcc-js/other": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/marshaller/package.json
+++ b/packages/marshaller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/marshaller",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "hpcc-js - Viz Marshaller",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,18 +25,18 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/chart": "^0.0.74",
-    "@hpcc-js/codemirror": "^0.0.86",
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/comms": "^0.0.77",
-    "@hpcc-js/composite": "^0.0.78",
-    "@hpcc-js/dgrid": "^0.0.83",
-    "@hpcc-js/form": "^0.0.74",
-    "@hpcc-js/graph": "^0.0.73",
-    "@hpcc-js/layout": "^0.0.72",
-    "@hpcc-js/other": "^0.0.72",
-    "@hpcc-js/phosphor": "^0.0.75",
-    "@hpcc-js/util": "^0.0.70"
+    "@hpcc-js/chart": "^0.0.75",
+    "@hpcc-js/codemirror": "^0.0.87",
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/comms": "^0.0.78",
+    "@hpcc-js/composite": "^0.0.79",
+    "@hpcc-js/dgrid": "^0.0.84",
+    "@hpcc-js/form": "^0.0.75",
+    "@hpcc-js/graph": "^0.0.74",
+    "@hpcc-js/layout": "^0.0.73",
+    "@hpcc-js/other": "^0.0.73",
+    "@hpcc-js/phosphor": "^0.0.76",
+    "@hpcc-js/util": "^0.0.71"
   },
   "devDependencies": {
     "@hpcc-js/ddl-shim": "^0.0.33",

--- a/packages/other/package.json
+++ b/packages/other/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/other",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz Other",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,9 +25,9 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/layout": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/layout": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/phosphor/package.json
+++ b/packages/phosphor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/phosphor",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "description": "hpcc-js - Viz Phosphor",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,9 +25,9 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72",
-    "@hpcc-js/other": "^0.0.72",
-    "@hpcc-js/util": "^0.0.70"
+    "@hpcc-js/common": "^0.0.73",
+    "@hpcc-js/other": "^0.0.73",
+    "@hpcc-js/util": "^0.0.71"
   },
   "devDependencies": {
     "@hpcc-js/phosphor-shim": "^0.0.61",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/react",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz React",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,7 +25,7 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/timeline",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "hpcc-js - Viz Timeline",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,8 +25,8 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/chart": "^0.0.74",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/chart": "^0.0.75",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/tree",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "hpcc-js - Viz Tree",
   "main": "dist/index.js",
   "module": "dist/index.es6",
@@ -25,8 +25,8 @@
     "docs": "typedoc --options tdoptions.json ."
   },
   "dependencies": {
-    "@hpcc-js/api": "^0.0.72",
-    "@hpcc-js/common": "^0.0.72"
+    "@hpcc-js/api": "^0.0.73",
+    "@hpcc-js/common": "^0.0.73"
   },
   "devDependencies": {
     "concurrently": "3.5.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hpcc-js/util",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "hpcc-js - Utilities",
   "main": "dist/index.js",
   "module": "dist/index.es6",


### PR DESCRIPTION
 - @hpcc-js/amchart@0.0.73
 - @hpcc-js/api@0.0.73
 - @hpcc-js/c3chart@0.0.74
 - @hpcc-js/chart@0.0.75
 - @hpcc-js/codemirror@0.0.87
 - @hpcc-js/common@0.0.73
 - @hpcc-js/comms@0.0.78
 - @hpcc-js/composite@0.0.79
 - @hpcc-js/dgrid@0.0.84
 - @hpcc-js/eclwatch@0.0.3
 - @hpcc-js/form@0.0.75
 - @hpcc-js/google@0.0.73
 - @hpcc-js/graph@0.0.74
 - @hpcc-js/handson@0.0.73
 - @hpcc-js/html@0.0.73
 - @hpcc-js/layout@0.0.73
 - @hpcc-js/map@0.0.78
 - @hpcc-js/marshaller@0.0.87
 - @hpcc-js/other@0.0.73
 - @hpcc-js/phosphor@0.0.76
 - @hpcc-js/react@0.0.73
 - @hpcc-js/timeline@0.0.75
 - @hpcc-js/tree@0.0.73
 - @hpcc-js/util@0.0.71