### PR TITLE
refactor:  Lerna publish call

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "test:chrome": "lerna run test:chrome --scope \"@hpcc-js/test-*\"",
     "test:firefox": "lerna run test:firefox --scope \"@hpcc-js/test-*\"",
     "test:ie": "lerna run test:ie --concurrency 1 --scope \"@hpcc-js/test-*\"",
-    "prep-publish": "npm run lint && npm run clean && npm run build && npm run minimize && npm run build-test && npm run test",
-    "publish": "npm run prep-publish && lerna publish --ignore \"@hpcc-js/test-*\" --ignore \"@hpcc-js/xxxx-*\" --ignore \"@hpcc-js/demo-*\"",
+    "publish-prep": "npm run lint && npm run clean && npm run build && npm run minimize && npm run build-test && npm run test",
+    "publish-lerna": "lerna publish --conventional-commits --ignore \"@hpcc-js/test-*\" --ignore \"@hpcc-js/xxxx-*\" --ignore \"@hpcc-js/demo-*\"",
+    "publish-test": "npm run publish-lerna -- --skip-npm --skip-git",
+    "publish": "npm run publish-prep && npm run publish-lerna",
     "legacy-test": "gulp lint && gulp jscs && gulp unitTest && gulp build-all && gulp unitTestBuild && gulp unitTestBuildNonAMD"
   },
   "devDependencies": {


### PR DESCRIPTION
Add new option to test a publish without updating git + npm
Start using Conventional Commits (https://conventionalcommits.org/)

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>