### PR TITLE
fix:  Add extra references to assist the DDL2 schema generation

### DIFF
--- a/packages/ddl-shim/src/ddl2.ts
+++ b/packages/ddl-shim/src/ddl2.ts
@@ -5,12 +5,13 @@ export type IServiceType = "wuresult" | "hipie" | "roxie";
 export type IDatasourceType = IServiceType | "logicalfile" | "form" | "databomb";
 export type DatasourceType = ILogicalFile | IForm | IDatabomb | IWUResult | IHipieService | IRoxieService;
 
-export type IPrimativeFieldType = "boolean" | "number" | "number64" | "string";
-export type IFieldType = IPrimativeFieldType | "range" | "dataset" | "object";
+export type IPrimative = boolean | number | string;
+export type IRange = [undefined | IPrimative, undefined | IPrimative];
+export type IFieldType = "boolean" | "number" | "number64" | "string" | "range" | "dataset" | "object";
 export interface IField {
     id: string;
     type: IFieldType;
-    default?: boolean | number | string | [undefined | IPrimativeFieldType, undefined | IPrimativeFieldType] | IField[];
+    default?: IPrimative | IRange | IField[];
     children?: IField[];
 }
 
@@ -262,7 +263,47 @@ export interface IView {
 
 //  DDL  ======================================================================
 export interface Schema {
-    version: "0.0.21";
+    version: "0.0.22";
     datasources: DatasourceType[];
     dataviews: IView[];
+    //  The following defs are only provided to assist the Java code generation (from the the generated schema)  ---
+    defs?: {
+        fieldTypes: {
+            field: IField;
+            primative: IPrimative;
+            range: IRange;
+        };
+        datasourceTypes: {
+            datasource: IDatasource;
+            logicalFile: ILogicalFile;
+            form: IForm;
+            databomb: IDatabomb;
+            wuresult: IWUResult;
+            hipieService: IHipieService;
+            roxieService: IRoxieService;
+        };
+        datasourceRefTypes: {
+            wuResultRef: IWUResultRef;
+            roxieServiceRef: IRoxieServiceRef;
+        };
+        activityTypes: {
+            filter: IFilter;
+            project: IProject;
+            groupby: IGroupBy;
+            sort: ISort;
+            limit: ILimit;
+            mappings: IMappings;
+        };
+        aggregateTypes: {
+            aggregate: IAggregate;
+            count: ICount;
+        };
+        transformationTypes: {
+            equals: IEquals;
+            calculated: ICalculated;
+            scale: IScale;
+            template: ITemplate;
+            map: IMap;
+        };
+    };
 }

--- a/packages/ddl-shim/src/upgrade.ts
+++ b/packages/ddl-shim/src/upgrade.ts
@@ -544,7 +544,7 @@ class DDLUpgrade {
                     return {
                         type: "range" as DDL2.IFieldType,
                         id: field.id,
-                        default: field.properties.default ? field.properties.default as [DDL2.IPrimativeFieldType, DDL2.IPrimativeFieldType] : [undefined, undefined]
+                        default: field.properties.default ? field.properties.default as [DDL2.IPrimative, DDL2.IPrimative] : [undefined, undefined]
                     };
                 case "dataset":
                     return {
@@ -581,7 +581,7 @@ class DDLUpgrade {
 
     output2output(output: DDL1.IOutput, target: DDL2.OutputDict) {
         target[output.id] = {
-            fields: []// this.filters2fields(output.filter)
+            fields: this.filters2fields(output.filter)
         };
     }
 
@@ -592,11 +592,11 @@ class DDLUpgrade {
             return idParts.length === 1 || idParts[1] === "range";
         }).map(filter => {
             const idParts = filter.fieldid.split("-");
-            return {
-                type: "string" as DDL2.IFieldType,
+            const retVal: DDL2.IField = {
                 id: idParts[0],
-                default: ""
+                type: "string"
             };
+            return retVal;
         });
     }
 
@@ -626,7 +626,7 @@ class DDLUpgrade {
 
     write(): DDL2.Schema {
         return {
-            version: "0.0.21",
+            version: "0.0.22",
             datasources: this.writeDatasources(),
             dataviews: this.writeDataviews()
         };

--- a/packages/marshaller/src/ddl2/activities/databomb.ts
+++ b/packages/marshaller/src/ddl2/activities/databomb.ts
@@ -50,10 +50,9 @@ export class Databomb extends Activity {
         for (row0 of this._jasonData) {
             const retVal: DDL2.IField[] = [];
             for (const key in row0) {
-                const rowType: DDL2.IPrimativeFieldType = typeof row0[key] as DDL2.IPrimativeFieldType;
                 retVal.push({
                     id: key,
-                    type: rowType
+                    type: typeof row0[key] as DDL2.IFieldType
                 });
             }
             return retVal;
@@ -134,7 +133,7 @@ export class Form extends Activity {
             retVal.push(
                 {
                     id: key,
-                    type: typeof row0[key] as DDL2.IPrimativeFieldType,
+                    type: typeof row0[key] as DDL2.IFieldType,
                     default: row0[key]
                 });
         }

--- a/packages/marshaller/src/ddl2/activities/sort.ts
+++ b/packages/marshaller/src/ddl2/activities/sort.ts
@@ -136,7 +136,6 @@ export class Sort extends Activity {
         }
 
         if (sortByArr.length) {
-            console.log("Sort Len:  " + data.length);
             return [...data].sort((l: any, r: any) => {
                 for (const item of sortByArr) {
                     const retVal2 = item.compare(l[item.id], r[item.id]);


### PR DESCRIPTION
While not strictly needed it helps with the Java code generation.
Add known fields to the outputs during update.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>