### PR TITLE
chore: Lock down d3-dsv type information

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/d3-scale": "1",
+    "@types/d3-dsv": "1",
     "colorbrewer": "1.0.0",
     "concurrently": "3.5.1",
     "cpx": "1.5.0",


### PR DESCRIPTION
Was preventing a clean build.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>