### PR TITLE
feat(marshaller): Add json/TreeFormat.ts

### DIFF
--- a/packages/marshaller/src/index.ts
+++ b/packages/marshaller/src/index.ts
@@ -25,3 +25,4 @@ export * from "./ddl2/activities/limit";
 export * from "./ddl2/activities/logicalfile";
 export * from "./ddl2/dashboard";
 export * from "./dashy";
+export * from "./json/TreeFormat";

--- a/packages/marshaller/src/json/TreeFormat.ts
+++ b/packages/marshaller/src/json/TreeFormat.ts
@@ -1,0 +1,39 @@
+
+export function TreeFormat(json: string | object): TreeDataFormat { // Maybe write interfaces for all of our expected data formats?
+    return obj_to_tree({label: "root"}, typeof json === "string" ? JSON.parse(json) : json);
+
+    function obj_to_tree(visitor, _data) {
+        switch (typeof _data) {
+            case "object":
+                if (_data !== null) {
+                    if (_data instanceof Array) {
+                        visitor.children = _data.map((row, row_idx) => {
+                            return this.obj_to_tree({label: row_idx}, row);
+                        });
+                    } else {
+                        visitor.children = [];
+                        for (const obj_idx in _data) {
+                            const row = _data[obj_idx];
+                            visitor.children.push(this.obj_to_tree({label: obj_idx}, row));
+                        }
+                    }
+                }
+                break;
+            case "number":
+            case "string":
+                if (typeof visitor.children === "undefined") {
+                    visitor.label += ` (${("" + _data)})`;
+                    visitor.size = ("" + _data).length;
+                }
+                break;
+        }
+        return visitor;
+    }
+}
+
+export interface TreeDataFormat {
+    label: string;
+    children?: TreeDataFormat[];
+    size?: number;
+    weight?: number;
+}


### PR DESCRIPTION
@GordonSmith this TreeFormat.ts might not necessarily belong in marshaller package, but it seems true to the definition of "marshalling". It's just a simple script I wrote that converts any/all json shapes into this format that can be consumed by any of the tree widgets:
`export interface TreeDataFormat {
    label: string;
    children?: TreeDataFormat[];
    size?: number;
    weight?: number;
}`

Signed-off-by: Jaman Brundage <jbrundage372@gmail.com>