### PR TITLE
feat: Add performance logging to ScopedLogging

### DIFF
--- a/demos/dermatology/www/index-dev.html
+++ b/demos/dermatology/www/index-dev.html
@@ -367,6 +367,26 @@
             }
 
         };
+        function show_performance(){
+            legacyRequire(["src/layout/Modal", "src/timeline/MiniGantt"], function(Modal, Timeline) {
+                let _data = app._logger.getPerfData(true)
+                    .map(row=>row.length===3 ? [row[0] + ` (${row[2] - row[1]}ms)`, row[1], row[2]] : row)
+                    ;
+                const _timeline = new Timeline()
+                    .timePattern("%Q")
+                    .tickFormat("%M:%S.%L")
+                    .tooltipTimeFormat("%M:%S.%L")
+                    .columns(["A", "B", "C"])
+                    .data(_data);
+                new Modal()
+                    .relativeTargetId("cellSurface")
+                    .target("cellSurface")
+                    .title("Performance Timeline")
+                    .widget(_timeline)
+                    .render()
+                    ;
+            });
+        }
     </script>
 </body>
 

--- a/packages/util/src/logging.ts
+++ b/packages/util/src/logging.ts
@@ -147,6 +147,8 @@ export const logger = Logging.Instance();
 
 export class ScopedLogging {
     protected _scopeID: string;
+    protected _performance_start_times: {[key: string]: number[]} = {};
+    protected _performance_end_times: {[key: string]: number[]} = {};
 
     constructor(scopeID: string) {
         this._scopeID = scopeID;
@@ -192,6 +194,29 @@ export class ScopedLogging {
     popLevel(): this {
         logger.popLevel();
         return this;
+    }
+
+    perfStart(name: string) {
+        if (typeof this._performance_start_times[name] === "undefined")this._performance_start_times[name] = [];
+        this._performance_start_times[name].push(Date.now());
+    }
+    perfEnd(name: string) {
+        if (typeof this._performance_end_times[name] === "undefined")this._performance_end_times[name] = [];
+        this._performance_end_times[name].push(Date.now());
+    }
+
+    getPerfData(ranges_only?: boolean) {
+        type perfType = [string, number, number] | [string, number];
+        const ret: perfType[] = [];
+        Object.keys(this._performance_end_times).forEach(name => {
+            this._performance_end_times[name].forEach((time2: any, i: any) => {
+                const time1 = this._performance_start_times[name][i];
+                if (!ranges_only || time1 !== time2) {
+                    ret.push(time1 === time2 ? [name, time1] : [name, time1, time2]);
+                }
+            });
+        });
+        return ret;
     }
 }
 


### PR DESCRIPTION
logger.perfStart("measurement_name") and logger.perfEnd("measurement_name") can be placed throughout code and logger.getPerfData() retrieves the performance measurements in a data format that timeline_MiniGantt can consume.

Signed-off-by: Jaman Brundage <jbrundage372@gmail.com>