### PR TITLE
fix(eclwatch): Hide canvas text Calculator

### DIFF
--- a/packages/common/src/Widget.css
+++ b/packages/common/src/Widget.css
@@ -2,3 +2,7 @@
     font-family: Verdana, Geneva, sans-serif;
     font-size: 12px;
 }
+
+#hpcc_js_font_size {
+    display: none;
+}


### PR DESCRIPTION
Hide the canvas div used to calculate the text sizes.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>