### PR TITLE
fix(dgrid-shim): Polluting global namespace with require

### DIFF
--- a/packages/dgrid-shim/package.json
+++ b/packages/dgrid-shim/package.json
@@ -21,13 +21,6 @@
     "types/*"
   ],
   "dependencies": {
-    "dgrid": "1.2.1",
-    "dijit": "1.13.0",
-    "dojo": "1.13.0",
-    "dojo-dstore": "1.1.2",
-    "dojo-themes": "1.13.0",
-    "dojo-util": "1.13.0",
-    "dojox": "1.13.0",
     "tslib": "1.9.0"
   },
   "devDependencies": {
@@ -35,7 +28,14 @@
     "@types/dojo": "1.9.40",
     "copy-webpack-plugin": "4.5.2",
     "css-loader": "1.0.0",
+    "dgrid": "1.2.1",
+    "dijit": "1.13.0",
+    "dojo": "1.13.0",
+    "dojo-dstore": "1.1.2",
+    "dojo-themes": "1.13.0",
+    "dojo-util": "1.13.0",
     "dojo-webpack-plugin": "2.7.4",
+    "dojox": "1.13.0",
     "rimraf": "2.6.2",
     "style-loader": "0.19.0",
     "tslint": "5.9.1",

--- a/packages/dgrid-shim/webpack.config.js
+++ b/packages/dgrid-shim/webpack.config.js
@@ -67,6 +67,7 @@ module.exports = function (env) {
                 buildEnvironment: { dojoRoot: "../../node_modules" }, // used at build time
                 locales: ["en"]
             }),
+            new DojoWebpackPlugin.ScopedRequirePlugin(),
             // Copy non-packed resources needed by the app to the release directory
             new CopyWebpackPlugin([{
                 context: "../../node_modules",


### PR DESCRIPTION
Streamline runtime dependencies (for downstream npm installs)

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>