### PR TITLE
feat(comms): Export hookSend from marshaller

### DIFF
--- a/packages/marshaller/src/index.ts
+++ b/packages/marshaller/src/index.ts
@@ -9,6 +9,7 @@ export * from "./ddl1/HTML";
 export * from "./ddl1/Tabbed";
 export * from "./ddl1/TargetMarshaller";
 */
+export { hookSend } from "@hpcc-js/comms";
 export * from "./ddl2/ddl";
 export * from "./ddl2/graphadapter";
 export * from "./ddl2/javascriptadapter";


### PR DESCRIPTION
If a consumer is using the marshaller and a different version of comms, then they had no way of hooking the marshaller comms layer.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>