### PR TITLE
fix(ddl-shim): npx @hpcc-js/ddl-shim fails with missing module "tslib"

### DIFF
--- a/packages/ddl-shim/package.json
+++ b/packages/ddl-shim/package.json
@@ -15,7 +15,7 @@
   ],
   "bin": "./bin/index.js",
   "scripts": {
-    "clean": "rimraf ./src/ddl*Schema*.ts && rimraf lib* && rimraf dist && rimraf types",
+    "clean": "rimraf ./src/ddl*Schema*.ts || rimraf lib* || rimraf dist || rimraf types",
     "compile-es6": "tsc --module es6 --outDir ./lib-es6",
     "compile-es6-watch": "npm run compile-es6 -- -w",
     "compile-cli": "tsc -p ./tsconfig-cli.json",

--- a/packages/ddl-shim/tsconfig-cli.json
+++ b/packages/ddl-shim/tsconfig-cli.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./lib-cli",
-        "module": "commonjs"
+        "module": "commonjs",
+        "importHelpers": false
     },
     "include": [
         "cli/*"


### PR DESCRIPTION
cli version should include tslib functions via importHelpers=false

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>