### PR TITLE
fix(GMapPin): Tooltips broken on layered surfaces

### DIFF
--- a/packages/api/src/ITooltip.ts
+++ b/packages/api/src/ITooltip.ts
@@ -21,6 +21,9 @@ export abstract class ITooltip extends Widget {
         if (this.layerEnter) {
             const layerEnter = this.layerEnter;
             this.layerEnter = function (_base, svgElement, _domElement) {
+                if (!this._parentOverlay) {
+                    this._parentOverlay = _base._parentOverlay;
+                }
                 this.tooltipEnter(svgElement);
                 layerEnter.apply(this, arguments);
             };

--- a/packages/map/src/Pins.css
+++ b/packages/map/src/Pins.css
@@ -1,16 +1,18 @@
-.map_Layered .pin {
+.map_Layered .pin > path {
     cursor: pointer;
     stroke: #000000;
 }
 
-.map_Layered .pin.selected {
+.map_Layered .pin.selected > path {
+    stroke-width: 1px;
     stroke: red;
 }
 
-.map_Layered .pin.over {
+.map_Layered .pin.over > path {
     stroke: orange;
 }
 
-.map_Layered .pin.selected.over {
+.map_Layered .pin.selected.over > path {
+    stroke-width: 1px;
     stroke: red;
 }

--- a/packages/map/src/Pins.ts
+++ b/packages/map/src/Pins.ts
@@ -30,10 +30,11 @@ export class Pins extends Layer {
                 return false;
             }
             return true;
-        }).map(function (row) {
+        }).map(function (row, idx) {
             const lat = latField ? row[latField.idx] : row[0];
             const long = longField ? row[longField.idx] : row[1];
             const retVal = {
+                idx,
                 lat,
                 long,
                 ext: row[2] instanceof Object ? row[2] : {},
@@ -72,7 +73,7 @@ export class Pins extends Layer {
             .style("opacity", this.opacity())
             ;
 
-        this.pinsPaths = this._pinsTransform.selectAll(".pin").data(this.visible() ? this.pinsData() : []);
+        this.pinsPaths = this._pinsTransform.selectAll(".pin").data(this.visible() ? this.pinsData() : [], d => d.idx);
         const context = this;
         const updatesPaths = this.pinsPaths.enter().append("g")
             .attr("class", "pin")
@@ -301,7 +302,7 @@ Pins.prototype.publish("fillColor", "#00FFDD", "html-color", "Pin Color", null, 
 Pins.prototype.publish("omitNullLatLong", false, "boolean", "Remove lat=0,lng=0 from pinsData", null, { tags: ["Basic"] });
 
 Pins.prototype.publish("strokeWidth", 0.5, "number", "Pin Border Thickness (pixels)", null, { tags: ["Basic"] });
-Pins.prototype.publish("strokeColor", "black", "html-color", "Pin Border Color", null, { optional: true });
+Pins.prototype.publish("strokeColor", "", "html-color", "Pin Border Color", null, { optional: true });
 
 Pins.prototype.publish("fontSize", 18, "number", "Font Size", null, { tags: ["Basic", "Shared"] });
 Pins.prototype.publish("fontFamily", "Verdana", "string", "Font Name", null, { tags: ["Basic", "Shared", "Shared"] });


### PR DESCRIPTION
Pins had hard coded black stroke, preventing selection from showing.
Selection would get out of sync on re-render.

Fixes GH-2796

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>