### PR TITLE
fix(DockPanel): DockPanel.render not rendering internal widgets

### DIFF
--- a/packages/phosphor/src/DockPanel.ts
+++ b/packages/phosphor/src/DockPanel.ts
@@ -81,6 +81,8 @@ export class DockPanel extends HTMLWidget implements IMessageHandler, IMessageHo
             .style("height", this.height() + "px")
             ;
 
+        this.widgets().forEach(w => w.render());
+
         this._dock.update();
     }
 
@@ -88,7 +90,7 @@ export class DockPanel extends HTMLWidget implements IMessageHandler, IMessageHo
         super.exit(domNode, element);
     }
 
-    render(callback) {
+    render(callback?: (w: Widget) => void): this {
         const context = this;
         return super.render((w) => {
             setTimeout(() => {


### PR DESCRIPTION
Render prototype incorrect

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>