### PR TITLE
fix(graph): Use Vertex.pos as starting position

### DIFF
--- a/packages/graph/src/Graph.ts
+++ b/packages/graph/src/Graph.ts
@@ -129,10 +129,6 @@ export class Graph extends SVGZoomWidget {
             const context = this;
             data.addedVertices.forEach(function (item) {
                 item._graphID = context._id;
-                item.pos({
-                    x: +Math.random() * 10 / 2 - 5,
-                    y: +Math.random() * 10 / 2 - 5
-                });
             });
             data.addedEdges.forEach(function (item) {
                 item._graphID = context._id;
@@ -396,7 +392,7 @@ export class Graph extends SVGZoomWidget {
             d3Select(this).style("cursor", context.allowDragging() ? "move" : "pointer");
             d
                 .target(this)
-                .pos({ x: width / 2, y: height / 2 })
+                .pos({ x: d.x() || width / 2, y: d.y() || height / 2 })
                 .animationFrameRender()
                 ;
             if (context.allowDragging()) {

--- a/packages/graph/src/Vertex.ts
+++ b/packages/graph/src/Vertex.ts
@@ -23,6 +23,7 @@ export class Vertex extends SVGWidget {
         this._icon = new Icon();
         this._textBox = new TextBox();
         this._annotationWidgets = {};
+        this.pos({ x: undefined, y: undefined });
     }
 
     getIconBBox() {


### PR DESCRIPTION
If the user has set a pos for a Vertex, use it as its starting position.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>