### PR TITLE
fix(dashy): active WA top border is now red

### DIFF
--- a/packages/phosphor/src/DockPanel.css
+++ b/packages/phosphor/src/DockPanel.css
@@ -15,6 +15,8 @@
   min-width: 0;
   min-height: 0;
   align-items: flex-end;
+}
+.p-TabPanel-tabBar .p-TabBar-content {
   border-bottom: 1px solid #C0C0C0;
 }
 

--- a/packages/phosphor/src/WidgetAdapter.css
+++ b/packages/phosphor/src/WidgetAdapter.css
@@ -9,7 +9,10 @@
 
 .phosphor_WidgetAdapter.p-DockPanel-widget {
   border-top: none;
-  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 0px -1px 0px rgba(0, 0, 0, 0.2), 1px 1px 2px rgba(0, 0, 0, 0.2);
+}
+.phosphor_WidgetAdapter.p-DockPanel-widget.active {
+  box-shadow: 0px -1px 0px rgba(85, 137, 255, 1), 1px 1px 2px rgba(0, 0, 0, 0.2);
 }
 
 .phosphor_WidgetAdapter.p-SplitPanel-child {


### PR DESCRIPTION
Cursor pointer indicates clickable widget adapter tabs
Fixes #3010

Signed-off-by: Jaman Brundage <jbrundage372@gmail.com>