### PR TITLE
fix(marshaller): Race condition

### DIFF
--- a/demos/dashy/src/index.ts
+++ b/demos/dashy/src/index.ts
@@ -1,11 +1,27 @@
 ﻿import { event as d3Event } from "@hpcc-js/common";
 import { Connection, Result } from "@hpcc-js/comms";
-import { Dashy, Databomb, Form, LogicalFile, RoxieResult, RoxieService, WU, WUResult, ElementContainer, Dashboard } from "@hpcc-js/marshaller";
+import { Dashboard, Dashy, Databomb, ElementContainer, Form, LogicalFile, RoxieResult, RoxieService, WU, WUResult } from "@hpcc-js/marshaller";
 import { Comms } from "@hpcc-js/other";
 import { exists, scopedLogger } from "@hpcc-js/util";
 import { sample } from "./sample";
 
 const logger = scopedLogger("index.ts");
+
+/* Test race condition  ---
+import { hookSend, IOptions, ResponseType, SendFunc } from "@hpcc-js/comms";
+let delay = 0;
+const origSend: SendFunc = hookSend(function mySend(opts: IOptions, action: string, request: any, responseType: ResponseType) {
+    return new Promise((resolve, reject) => {
+        origSend(opts, action, request, responseType).then(response => {
+            delay += 1000;
+            if (delay > 5000) delay = 0;
+            setTimeout(() => {
+                resolve(response);
+            }, delay);
+        });
+    });
+});
+*/
 
 export class App {
     _dashy = new Dashy();

--- a/packages/util/src/debounce.ts
+++ b/packages/util/src/debounce.ts
@@ -52,3 +52,31 @@ export function promiseTimeout<T>(ms: number, promise: Promise<T>) {
         throw e;
     });
 }
+
+export class AsyncOrderedQueue {
+    private _q: Array<Promise<any>> = [];
+
+    private isTop(p: Promise<any>): boolean {
+        return this._q[0] === p;
+    }
+
+    push<T>(p: Promise<T>): Promise<T> {
+        const retVal = p.then(response => {
+            if (this.isTop(retVal)) {
+                this._q.shift();
+                return response;
+            }
+            return new Promise<T>((resolve, reject) => {
+                const intervalHandler = setInterval(() => {
+                    if (this.isTop(retVal)) {
+                        clearInterval(intervalHandler);
+                        this._q.shift();
+                        resolve(response);
+                    }
+                }, 20);
+            });
+        });
+        this._q.push(retVal);
+        return retVal;
+    }
+}

--- a/tests/test-util/src/debounce.spec.ts
+++ b/tests/test-util/src/debounce.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { debounce } from "@hpcc-js/util";
+import { AsyncOrderedQueue, debounce } from "@hpcc-js/util";
 
 describe("debounce", function () {
     let funcCallCount = 0;
@@ -82,5 +82,91 @@ describe("debounce", function () {
                 resolve();
             }, 0);
         });
+    });
+});
+
+function doStuff(id: number, delay: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            resolve(id);
+        }, delay);
+    });
+}
+describe("AsyncOrderedQueue", function () {
+    it("single", async function (): Promise<void> {
+        const q = new AsyncOrderedQueue();
+        let currID = 0;
+        return Promise.all([
+            q.push(doStuff(1, 1000)).then(id => {
+                expect(currID).to.equal(0);
+                currID = id;
+            })
+        ]).then(response => { });
+    });
+    it("natural order", async function (): Promise<void> {
+        const q = new AsyncOrderedQueue();
+        let currID = 0;
+        return Promise.all([
+            q.push(doStuff(1, 100)).then(id => {
+                expect(currID).to.equal(0);
+                currID = id;
+            }),
+            q.push(doStuff(2, 200)).then(id => {
+                expect(currID).to.equal(1);
+                currID = id;
+            }),
+            q.push(doStuff(3, 300)).then(id => {
+                expect(currID).to.equal(2);
+                currID = id;
+            }),
+            q.push(doStuff(4, 400)).then(id => {
+                expect(currID).to.equal(3);
+                currID = id;
+            })
+        ]).then(response => { });
+    });
+    it("reverse order", async function (): Promise<void> {
+        const q = new AsyncOrderedQueue();
+        let currID = 0;
+        return Promise.all([
+            q.push(doStuff(1, 400)).then(id => {
+                expect(currID).to.equal(0);
+                currID = id;
+            }),
+            q.push(doStuff(2, 300)).then(id => {
+                expect(currID).to.equal(1);
+                currID = id;
+            }),
+            q.push(doStuff(3, 200)).then(id => {
+                expect(currID).to.equal(2);
+                currID = id;
+            }),
+            q.push(doStuff(4, 100)).then(id => {
+                expect(currID).to.equal(3);
+                currID = id;
+            })
+        ]).then(response => { });
+    });
+    it("random order", async function (): Promise<void> {
+        const q = new AsyncOrderedQueue();
+        let currID = 0;
+        return Promise.all([
+            q.push(doStuff(1, 400 * Math.random())).then(id => {
+                expect(currID).to.equal(0);
+                currID = id;
+            }),
+            q.push(doStuff(2, 400 * Math.random())).then(id => {
+                expect(currID).to.equal(1);
+                currID = id;
+            }),
+            q.push(doStuff(3, 400 * Math.random())).then(id => {
+                expect(currID).to.equal(2);
+                currID = id;
+            }),
+            q.push(doStuff(4, 400 * Math.random())).then(id => {
+                expect(currID).to.equal(3);
+                currID = id;
+            })
+        ]).then(response => { });
     });
 });


### PR DESCRIPTION
Service calls need to preserve order they were called in, otherwise clicks could get out of sync.

Fixes GH-3106

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
