### PR TITLE
fix: Added overlap translate to XYAxis svgData

### DIFF
--- a/packages/chart/src/Axis.ts
+++ b/packages/chart/src/Axis.ts
@@ -27,6 +27,7 @@ export class Axis extends SVGWidget {
     protected svg;
     protected svgAxis;
     protected svgGuides;
+    _overlap;
 
     @publish("linear", "set", "Type", ["none", "ordinal", "linear", "pow", "log", "time"])
     _type: string;
@@ -538,10 +539,10 @@ export class Axis extends SVGWidget {
 
         this.svg.style("display", this.hidden() ? "none" : null);
 
-        const overlap = this.calcOverflow(_element);
+        this._overlap = this.calcOverflow(_element);
 
-        const lowerPos: number = this.isHorizontal() ? overlap.left : this.height() - overlap.top - overlap.bottom;
-        const upperPos: number = this.isHorizontal() ? this.width() - overlap.right : 0;
+        const lowerPos: number = this.isHorizontal() ? this._overlap.left : this.height() - this._overlap.top - this._overlap.bottom;
+        const upperPos: number = this.isHorizontal() ? this.width() - this._overlap.right : 0;
         this.range(this.reverse() ? [upperPos, lowerPos] : [lowerPos, upperPos]);
 
         const context = this;
@@ -549,13 +550,13 @@ export class Axis extends SVGWidget {
             element.attr("transform", function () {
                 switch (context.orientation()) {
                     case "left":
-                        return "translate(" + overlap.depth + ", " + overlap.top + ")";
+                        return "translate(" + context._overlap.depth + ", " + context._overlap.top + ")";
                     case "top":
-                        return "translate(0," + overlap.depth + ")";
+                        return "translate(0," + context._overlap.depth + ")";
                     case "right":
-                        return "translate(" + (context.width() - overlap.depth) + ", " + overlap.top + ")";
+                        return "translate(" + (context.width() - context._overlap.depth) + ", " + context._overlap.top + ")";
                     case "bottom":
-                        return "translate(0," + (context.height() - overlap.depth) + ")";
+                        return "translate(0," + (context.height() - context._overlap.depth) + ")";
                     default:
                 }
                 return "translate(0,0)";
@@ -576,7 +577,7 @@ export class Axis extends SVGWidget {
         this.svgAxis
             .call(this.d3Axis)
             ;
-        this.adjustText(this.svgAxis, overlap.tickOverlapModulus);
+        this.adjustText(this.svgAxis, this._overlap.tickOverlapModulus);
 
         const svgLineBBox = {
             x: this.pos().x,

--- a/packages/chart/src/XYAxis.ts
+++ b/packages/chart/src/XYAxis.ts
@@ -389,13 +389,14 @@ export class XYAxis extends SVGWidget {
             .tickLength(this.yAxisGuideLines() ? maxCurrExtent : 0)
             .render()
             ;
-
         this.svgDataClipRect
-            .attr("width", width)
-            .attr("height", height)
+            .attr("width", width - (isHorizontal ? this.xAxis._overlap.left : -this.yAxis._overlap.top))
+            .attr("height", height - (isHorizontal ? this.yAxis._overlap.top : -this.xAxis._overlap.left))
             ;
+        const transX = isHorizontal ? this.xAxis._overlap.left : -this.yAxis._overlap.top;
+        const transY = isHorizontal ? this.yAxis._overlap.top : -this.xAxis._overlap.left;
         this.svgData.transition()
-            .attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")")
+            .attr("transform", "translate(" + (this.margin.left + transX) + "," + (this.margin.top + transY) + ")")
             ;
 
         this.updateBrush(width, height, maxCurrExtent, isHorizontal);


### PR DESCRIPTION
Fixes #3126

Signed-off-by: Jaman Brundage <jbrundage372@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
I've tested the widgets that extend XYAxis in a standalone html page.
