### PR TITLE
fix(tooltip): Re-targeted widgets lose tooltip styling

### DIFF
--- a/packages/api/src/ITooltip.ts
+++ b/packages/api/src/ITooltip.ts
@@ -11,7 +11,7 @@ export abstract class ITooltip extends Widget {
     layerEnter;
     layerUpdate;
     layerExit;
-    tooltip = tip().attr("class", "d3-tip");
+    tooltip = tip();
 
     constructor() {
         super();
@@ -34,8 +34,8 @@ export abstract class ITooltip extends Widget {
             };
             const layerExit = this.layerExit;
             this.layerExit = function (_base) {
-                layerExit.apply(this, arguments);
                 this.tooltipExit();
+                layerExit.apply(this, arguments);
             };
         } else {
             const enter = this.enter;
@@ -50,8 +50,8 @@ export abstract class ITooltip extends Widget {
             };
             const exit = this.exit;
             this.exit = function (_domNode, _element) {
-                exit.apply(this, arguments);
                 this.tooltipExit();
+                exit.apply(this, arguments);
             };
         }
     }

--- a/packages/api/src/Tooltip.ts
+++ b/packages/api/src/Tooltip.ts
@@ -299,6 +299,7 @@ export function tip() {
     function initNode() {
         const div = select(document.createElement("div"));
         div
+            .attr("class", "d3-tip")
             .style("position", "absolute")
             .style("top", 0)
             .style("opacity", 0)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
