### PR TITLE
fix(eclwatch): Avoid accessing detailed subgraph stats for graph Timeline

### DIFF
--- a/packages/eclwatch/src/WUTimeline.ts
+++ b/packages/eclwatch/src/WUTimeline.ts
@@ -89,17 +89,17 @@ WUTimeline.prototype.publish("baseUrl", "", "string", "HPCC Platform Base URL");
 WUTimeline.prototype.publish("wuid", "", "string", "Workunit ID");
 WUTimeline.prototype.publish("request", {
     ScopeFilter: {
-        MaxDepth: 999999,
-        ScopeTypes: ["graph"]
+        MaxDepth: 3,
+        ScopeTypes: ["graph", "subgraph"]
     },
     NestedFilter: {
-        Depth: 999999,
-        ScopeTypes: ["graph", "subgraph"] // , "activity"]
+        Depth: 0,
+        ScopeTypes: []
     },
     PropertiesToReturn: {
-        AllProperties: true,
+        AllProperties: false,
         AllStatistics: true,
-        AllHints: true,
+        AllHints: false,
         Properties: ["WhenStarted", "TimeElapsed"]
     },
     ScopeOptions: {


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
