### PR TITLE
fix: ddlParamsFormat now allows spaces

### DIFF
--- a/src/common/Utility.js
+++ b/src/common/Utility.js
@@ -220,7 +220,7 @@
 
     //  Template   ---
     //  https://github.com/Matt-Esch/string-template (MIT)
-    var nargs = /\{([0-9a-zA-Z_\[\]]+)\}/g;
+    var nargs = /\{([0-9a-zA-Z_\s\[\]]+)\}/g;
     function template(string) {
         var args;
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [x] I have raised new issues to address them separately

## Testing:
Tested the change in isolation. 

#3150 was created to track the possibility that other characters should be supported as well.