### PR TITLE
fix(dgrid): Exit/Enter/Update Issue

### DIFF
--- a/packages/dgrid/src/Common.ts
+++ b/packages/dgrid/src/Common.ts
@@ -35,7 +35,7 @@ export class Common extends HTMLWidget {
     update(domNode, element) {
         super.update(domNode, element);
 
-        if (this._prevPaging !== this.pagination()) {
+        if (!this._dgrid || this._prevPaging !== this.pagination()) {
             this._prevPaging = this.pagination();
             if (this._dgrid) {
                 this._dgrid.destroy();
@@ -80,6 +80,10 @@ export class Common extends HTMLWidget {
 
     exit(domNode, element) {
         delete this._prevPaging;
+        if (this._dgrid) {
+            this._dgrid.destroy();
+            delete this._dgrid;
+        }
         super.exit(domNode, element);
     }
 


### PR DESCRIPTION
dgrid has intermittent crash, when moved from div to div.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
