### PR TITLE
feat: Add graph_ForceDirected

### DIFF
--- a/demos/gallery/samples/graph/ForceDirected.js
+++ b/demos/gallery/samples/graph/ForceDirected.js
@@ -1,0 +1,6 @@
+import { ForceDirected } from "@hpcc-js/graph";
+
+new ForceDirected()
+    .target("target")
+    .render()
+    ;

--- a/demos/gallery/samples/graph/GraphForceDirected.js
+++ b/demos/gallery/samples/graph/GraphForceDirected.js
@@ -1,0 +1,52 @@
+import { Palette } from "@hpcc-js/common";
+import { ForceDirected as Graph, Vertex, Edge } from "@hpcc-js/graph";
+
+new Graph()
+    .target("target")
+    .data(createData())
+    .render()
+    ;
+
+function createData() {
+    var vertices = [];
+    var edges = [];
+    const rawData = {
+        nodes: [
+            { "name": "John Doe", "icon": "" },
+            { "name": "Jane Doe", "icon": "" },
+            { "name": "123 Main Street", "icon": "", "centroid": true }
+        ],
+        "links": [
+            { "source": 2, "target": 0 },
+            { "source": 2, "target": 1 }
+        ]
+    };
+    rawData.nodes.forEach(function (node, idx) {
+        vertices.push(new Vertex()
+            .centroid(node.centroid)
+            .icon_diameter(60)
+            .icon_shape_colorStroke("transparent")
+            .icon_shape_colorFill("transparent")
+            .icon_image_colorFill("#333333")
+            .iconAnchor("middle")
+            .faChar(node.icon)
+            .textbox_shape_colorStroke("transparent")
+            .textbox_shape_colorFill("white")
+            .textbox_text_colorFill("#333333")
+            .text(node.name)
+        );
+    });
+
+    rawData.links.forEach(function (link, idx) {
+        edges.push(new Edge()
+            .sourceVertex(vertices[link.source])
+            .targetVertex(vertices[link.target])
+            .sourceMarker("circle")
+            .targetMarker("arrow")
+            .text("")
+            .weight(link.value)
+        );
+    });
+
+    return { vertices: vertices, edges: edges };
+}

--- a/packages/graph/src/ForceDirected.ts
+++ b/packages/graph/src/ForceDirected.ts
@@ -1,0 +1,127 @@
+import { SVGWidget } from "@hpcc-js/common";
+import { drag as d3Drag } from "d3-drag";
+import { forceCenter as d3ForceCenter, forceLink as d3ForceLink, forceManyBody as d3ForceManyBody, forceSimulation as d3ForceSimulation } from "d3-force";
+import { event as d3Event, select as d3Select } from "d3-selection";
+import { zoom as d3Zoom } from "d3-zoom";
+
+export class ForceDirected extends SVGWidget {
+    _g;
+    _zoom;
+    _drag;
+    _container;
+    _simulation;
+    constructor() {
+        super();
+    }
+    enter(domNode, element) {
+        super.enter(domNode, element);
+        this._container = element.append("g");
+        const context = this;
+        this._zoom = d3Zoom()
+            .on("zoom", function() {
+                context._container.attr("transform", d3Event.transform);
+            });
+        this._g = element.append("g")
+            .attr("class", "zoom_g")
+            .call(this._zoom)
+            ;
+        const size = this.size();
+        this._g.append("rect")
+            .attr("width", size.width)
+            .attr("height", size.height)
+            .attr("transform", `translate(${-size.width / 2} ${-size.height / 2})`)
+            .style("fill", "none")
+            .style("pointer-events", "all")
+            ;
+        this._drag = d3Drag()
+            .on("drag", function (d: any) {
+                d3Select(this).attr("cx", d.x = d3Event.x).attr("cy", d.y = d3Event.y);
+                context._simulation.alpha(0.1);
+                context._simulation.restart();
+                context._simulation.tick();
+            });
+    }
+    update(domNode, element) {
+        super.update(domNode, element);
+
+        const graph = this.useSampleData() ? this.sampleData(this.sampleDataCount()) : this.transformGraphData(this.data());
+
+        if (graph.nodes.length === 0) {
+            if (this._simulation) {
+                this._simulation.stop();
+            }
+        } else {
+            this._simulation = d3ForceSimulation()
+                .force("link", d3ForceLink().distance(80))
+                .force("charge", d3ForceManyBody().strength(-300))
+                .force("center", d3ForceCenter(150, 150));
+            this._simulation
+                .nodes(graph.nodes)
+                .on("tick", n => {
+                    link.attr("x1", d => d.source.x).attr("y1", d => d.source.y)
+                    .attr("x2", d => d.target.x).attr("y2", d => d.target.y);
+                    node.attr("cx", d => d.x).attr("cy", d => d.y);
+                });
+            this._simulation
+                .force("link").links(graph.links);
+            const link = this.enterLinkElement(graph);
+            const node = this.enterNodeElement(graph);
+        }
+    }
+
+    enterLinkElement(graphData) {
+        return this._container.selectAll(".link").data(graphData.links).enter().append("line")
+            .style("stroke", "#000").attr("class", "link")
+            ;
+    }
+
+    enterNodeElement(graphData) {
+        return this._container.selectAll(".node").data(graphData.nodes).enter().append("circle")
+            .attr("class", "node").style("fill", "#ccc").style("stroke", "#000").attr("r", 10)
+            .call(this._drag)
+            ;
+    }
+
+    transformGraphData(data) {
+        if (!data.vertices || !data.edges)return { nodes: [], edges: [] };
+        const idxMap = {};
+        const nodes = data.vertices.map((n, i) => {
+            idxMap[n.id()] = i;
+            return {id: i, label: n.text(), icon: n.faChar()};
+        });
+        const links = data.edges.map(edge => {
+            return {
+                source: idxMap[edge.sourceVertex().id()],
+                target: idxMap[edge.targetVertex().id()]
+            };
+        });
+        return { nodes, links };
+    }
+
+    sampleData(n) {
+        const nodeCount = n;
+        const ncSqrt = Math.ceil(Math.sqrt(nodeCount));
+        const ncSqrt2 = Math.ceil(Math.sqrt(ncSqrt));
+        const nodes = (Array(nodeCount) as any).fill(1).map((n, i) => {
+            return {id: i};
+        });
+
+        const links = nodes.reduce((acc, n) => {
+            if (n.id > 0) acc.push({ source: n.id, target: n.id - 1 });
+            if (n.id > ncSqrt2) acc.push({ source: n.id, target: n.id - ncSqrt2 });
+            return acc;
+        }, []);
+
+        return { links, nodes };
+    }
+}
+ForceDirected.prototype._class += " graph_ForceDirected";
+
+export interface ForceDirected {
+    useSampleData(): boolean;
+    useSampleData(_: boolean): this;
+    sampleDataCount(): number;
+    sampleDataCount(_: number): this;
+}
+ForceDirected.prototype.publish("sampleDataCount", 100, "number", "Number of nodes in sample data", undefined, { disable: w => !w.useSampleData() });
+ForceDirected.prototype.publish("useSampleData", false, "boolean", "Generate sample data");

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./__package__";
 export * from "./AdjacencyGraph";
 export * from "./Edge";
+export * from "./ForceDirected";
 export * from "./Graph";
 export * from "./Sankey";
 export * from "./Subgraph";

--- a/tests/test-graph/src/graph.spec.ts
+++ b/tests/test-graph/src/graph.spec.ts
@@ -1,7 +1,7 @@
 import { Class, HTMLWidget, Palette, SVGWidget } from "@hpcc-js/common";
 import * as graph from "@hpcc-js/graph";
 // tslint:disable-next-line:no-duplicate-imports
-import { AdjacencyGraph, Edge, Graph, Sankey, SankeyColumn, Subgraph, Vertex } from "@hpcc-js/graph";
+import { AdjacencyGraph, Edge, ForceDirected, Graph, Sankey, SankeyColumn, Subgraph, Vertex } from "@hpcc-js/graph";
 import { classDef, dataBreach, render } from "@hpcc-js/test-data";
 import { expect } from "chai";
 
@@ -143,6 +143,8 @@ describe("@hpcc-js/graph", () => {
                                         { faChar: "\uf193", tooltip: "Test C", shape_colorFill: "navy", shape_colorStroke: "navy", image_colorFill: "white" }
                                     ])
                                 );
+                                break;
+                            case ForceDirected:
                                 break;
                             default:
                                 it("Has render test", () => {


### PR DESCRIPTION
Signed-off-by: Jaman Brundage <jbrundage372@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [x] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
This is a simplified implementation of d3-force. A new widget can simply extend it and overwrite the `enterLinkElement` and `enterNodeElement` methods to reskin it. This widget can also serve as boilerplate when similar functionality needs to be applied to a widget.
