### PR TITLE
fix(build): Source maps not referencing TS files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5439,7 +5439,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5457,11 +5458,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5474,15 +5477,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5585,7 +5591,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5595,6 +5602,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5607,17 +5615,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5634,6 +5645,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5706,7 +5718,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5716,6 +5729,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5791,7 +5805,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5821,6 +5836,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5838,6 +5854,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5876,11 +5893,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -37,6 +37,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -60,6 +60,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/chart/rollup.config.js
+++ b/packages/chart/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/codemirror-shim/rollup.config.js
+++ b/packages/codemirror-shim/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -29,6 +30,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -38,6 +38,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/codemirror/rollup.config.js
+++ b/packages/codemirror/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -47,6 +48,7 @@ export default {
             namedExports: {
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -73,6 +73,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -30,6 +31,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -51,6 +51,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/comms/rollup.config.js
+++ b/packages/comms/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -14,9 +15,10 @@ const plugins = [
     }),
     commonjs({
     }),
+    sourcemaps(),
     postcss({
         extensions: [".css"],
-            minimize: true
+        minimize: true
     })
 ];
 

--- a/packages/composite/package.json
+++ b/packages/composite/package.json
@@ -49,6 +49,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/composite/rollup.config.js
+++ b/packages/composite/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/dgrid/package.json
+++ b/packages/dgrid/package.json
@@ -43,6 +43,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/dgrid/rollup.config.js
+++ b/packages/dgrid/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -50,6 +51,7 @@ export default {
                 "../dgrid-shim/dist/index.js": ["Deferred", "domConstruct", "QueryResults", "Memory", "PagingGrid", "Grid"]
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/eclwatch/package.json
+++ b/packages/eclwatch/package.json
@@ -44,6 +44,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/eclwatch/rollup.config.js
+++ b/packages/eclwatch/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -49,6 +50,7 @@ export default {
             namedExports: {
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -44,6 +44,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/form/rollup.config.js
+++ b/packages/form/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -48,6 +48,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/graph/rollup.config.js
+++ b/packages/graph/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -47,6 +48,7 @@ export default {
             namedExports: {
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -40,6 +40,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/html/rollup.config.js
+++ b/packages/html/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -46,6 +46,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/layout/rollup.config.js
+++ b/packages/layout/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/loader/rollup.config.js
+++ b/packages/loader/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -30,6 +31,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -55,6 +55,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "topojson": "3.0.2",
     "tslib": "1.10.0",

--- a/packages/map/rollup.config.js
+++ b/packages/map/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -53,6 +54,7 @@ export default {
                 "leaflet.gridlayer.googlemutant": ["GoogleMutant"]
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/marshaller/package.json
+++ b/packages/marshaller/package.json
@@ -54,6 +54,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/marshaller/rollup.config.js
+++ b/packages/marshaller/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -48,6 +49,7 @@ export default {
                 "../ddl-shim/dist/index.js": ["DDL1", "DDL2", "ddl2Schema", "isDDL2Schema", "upgrade", "validate2"]
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/other/package.json
+++ b/packages/other/package.json
@@ -50,6 +50,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "simpleheat": "0.4.0",
     "terser": "4.0.0",
     "tslib": "1.10.0",

--- a/packages/other/rollup.config.js
+++ b/packages/other/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/phosphor-shim/rollup.config.js
+++ b/packages/phosphor-shim/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 import replace from 'rollup-plugin-replace';
@@ -39,6 +40,7 @@ export default {
                 "@phosphor/widgets": ["BoxPanel", "CommandRegistry", "CommandPalette", "ContextMenu", "DockLayout", "DockPanel", "Message", "Menu", "MenuBar", "SplitPanel", "TabBar", "TabPanel", "Widget"]
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/phosphor/package.json
+++ b/packages/phosphor/package.json
@@ -41,6 +41,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/phosphor/rollup.config.js
+++ b/packages/phosphor/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/preact-shim/rollup.config.js
+++ b/packages/preact-shim/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -33,6 +34,7 @@ export default {
                 "..\\..\\node_modules\\preact\\dist\\preact.js": ["Component", "cloneElement", "h", "options", "render"]
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,6 +39,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -44,6 +44,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/timeline/rollup.config.js
+++ b/packages/timeline/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -45,6 +45,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/tree/rollup.config.js
+++ b/packages/tree/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -45,6 +46,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -36,6 +36,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.2",
     "rollup-plugin-postcss": "2.0.3",
+    "rollup-plugin-sourcemaps": "0.4.2",
     "terser": "4.0.0",
     "tslib": "1.10.0",
     "tslint": "5.17.0",

--- a/packages/util/rollup.config.js
+++ b/packages/util/rollup.config.js
@@ -1,6 +1,7 @@
 import { external, globals } from "@hpcc-js/bundle";
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -30,6 +31,7 @@ export default {
         }),
         commonjs({
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true

--- a/tests/test-dgrid/rollup.config.js
+++ b/tests/test-dgrid/rollup.config.js
@@ -1,4 +1,5 @@
 import commonjs from 'rollup-plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import postcss from "rollup-plugin-postcss";
 
@@ -28,6 +29,7 @@ export default {
                 //"@hpcc-js/dgrid-shim": ["Deferred", "domConstruct", "QueryResults", "Memory", "PagingGrid", "Grid"]
             }
         }),
+        sourcemaps(),
         postcss({
             extensions: [".css"],
             minimize: true


### PR DESCRIPTION
rollup-plugin-sourcemaps will use existing map files if they exist.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
