### PR TITLE
feat(v1): Add filter by Legend click

### DIFF
--- a/src/chart/MultiChart.js
+++ b/src/chart/MultiChart.js
@@ -120,6 +120,7 @@
     }, this);
 
     MultiChart.prototype.publishReset();
+    MultiChart.prototype.publish("hideRowOnLegendClick", false,"boolean","Enable/Disable hiding row on legend clicks", null, {tags:["Basic"]});
     MultiChart.prototype.publish("chartType", "BUBBLE", "set", "Chart Type", MultiChart.prototype._allChartTypes.map(function (item) { return item.id; }),{tags:["Basic"]});
     MultiChart.prototype.publish("chart", null, "widget", "Chart",null,{tags:["Basic"]});
 

--- a/src/composite/MegaChart.js
+++ b/src/composite/MegaChart.js
@@ -50,6 +50,7 @@
 
     MegaChart.prototype.publishReset();
 
+    MegaChart.prototype.publish("hideRowOnLegendClick", false,"boolean","Enable/Disable hiding row on legend clicks", null, {tags:["Basic"]});
     MegaChart.prototype.publish("showToolbar",true,"boolean","Enable/Disable Toolbar widget", null, {tags:["Basic"]});
     MegaChart.prototype.publishProxy("title", "_toolbar", "title");
     MegaChart.prototype.publish("ddlParamsFormat", "", "string", "DDL Param Format '{fname}, {lname}'", null, { tags: ["Advanced"], optional: true });
@@ -299,6 +300,10 @@
                     twArr.splice(idx, 1);
                 }
             }
+        }
+
+        if(this._chart && typeof this._chart.hideRowOnLegendClick === "function"){
+            this._chart.hideRowOnLegendClick(this.hideRowOnLegendClick());
         }
 
         this._dataCount.html('<span class="MegaChart-dataCount-label">Count:</span>&nbsp;<span class="MegaChart-dataCount-value">'+(this.data() ? this.data().length : "0")+'</span>');

--- a/test/compositeFactory.js
+++ b/test/compositeFactory.js
@@ -24,7 +24,34 @@
             pie: function (callback) {
                 require(["test/DataFactory", "src/composite/MegaChart"], function (DataFactory, MegaChart) {
                     var mc = new MegaChart()
-                        .chartType("C3_PIE")
+                        .chartType("PIE")
+                        .hideRowOnLegendClick(true)
+                        .legendPosition("bottom")
+                        .title("Simple MegaChart Title")
+                        .columns(DataFactory.ND.subjects.columns)
+                        .data(DataFactory.ND.subjects.data)
+                    ;
+                    callback(mc);
+                });
+            },
+            bar: function (callback) {
+                require(["test/DataFactory", "src/composite/MegaChart"], function (DataFactory, MegaChart) {
+                    var mc = new MegaChart()
+                        .chartType("BAR")
+                        .hideRowOnLegendClick(true)
+                        .legendPosition("bottom")
+                        .title("Simple MegaChart Title")
+                        .columns(DataFactory.ND.subjects.columns)
+                        .data(DataFactory.ND.subjects.data)
+                    ;
+                    callback(mc);
+                });
+            },
+            column: function (callback) {
+                require(["test/DataFactory", "src/composite/MegaChart"], function (DataFactory, MegaChart) {
+                    var mc = new MegaChart()
+                        .chartType("COLUMN")
+                        .hideRowOnLegendClick(true)
                         .legendPosition("bottom")
                         .title("Simple MegaChart Title")
                         .columns(DataFactory.ND.subjects.columns)


### PR DESCRIPTION
Fixes #3324

Signed-off-by: Jaman Brundage <jbrundage372@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [x] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
I've tested this in the dermatology editor and there are two edge case issues that can be experienced, but they may not be worth addressing in this pull request as this is an opt-in feature that will be primarily used on `PIE`. 
First issue: 
1) enable the `hideRowOnLegendClick` feature
2) hide a row
3) switch chart types
4) the previously hidden row is now missing from the dataset
Second issue:
1) change `chartType` to an ND chart
2) enable the `hideRowOnLegendClick` feature
3) click a legend label
4) a "row" is now missing (corresponding to the clicked legend index)... legend labels are based on "column"s for ND charts


