### PR TITLE
fix(SVGWidget): Incomplete feColorMatrix node can cause IE/Edge to crash

### DIFF
--- a/packages/common/src/SVGWidget.ts
+++ b/packages/common/src/SVGWidget.ts
@@ -111,6 +111,7 @@ export class SVGGlowFilter {
             .attr("result", "matrixOut")
             .attr("in", "offOut")
             .attr("type", "matrix")
+            .attr("values", this.rgb2ColorMatrix("red"))
             ;
         this.feGaussianBlur = this.filter.append("feGaussianBlur")
             .attr("result", "blurOut")


### PR DESCRIPTION
This will cause the page to "hard reload".

Fixes #3347

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
