### PR TITLE
fix(XYAxis): Range selection issues

### DIFF
--- a/packages/chart/src/XYAxis.ts
+++ b/packages/chart/src/XYAxis.ts
@@ -416,11 +416,13 @@ export class XYAxis extends SVGWidget {
         currBrush.extent([[0, 0], [width, height]]);
         this.svgBrush
             .attr("transform", "translate(" + this.margin.left + ", " + this.margin.top + ")")
-            .style("height", height)
+            .style(isHorizontal ? "height" : "width", this.use2dSelection() ? null : isHorizontal ? height : width)
+            .style(isHorizontal ? "width" : "height", null)
             .style("display", this.selectionMode() ? null : "none")
             .call(currBrush)
             .select(".selection")
-            .style("height", height)
+            .style(isHorizontal ? "height" : "width", this.use2dSelection() ? null : isHorizontal ? height : width)
+            .style(isHorizontal ? "width" : "height", null)
             ;
         const handleTypes = this.use2dSelection() ? [] : isHorizontal ? [{ type: "w" }, { type: "e" }] : [{ type: "n" }, { type: "s" }];
         const handlePath = this.svgBrush.selectAll(".handle--custom").data(handleTypes);

--- a/packages/chart/src/XYAxis.ts
+++ b/packages/chart/src/XYAxis.ts
@@ -250,7 +250,7 @@ export class XYAxis extends SVGWidget {
             top: !isHorizontal && this.selectionMode() ? 10 : 2,
             right: isHorizontal && (this.selectionMode() || this.xAxisFocus()) ? 10 : 2,
             bottom: (this.xAxisFocus() ? this.xAxisFocusHeight() : 0) + 2,
-            left: 2
+            left: this.yAxisHidden() && this.selectionMode() ? 10 : 2
         };
         const width = this.width() - margin.left - margin.right;
         const height = this.height() - margin.top - margin.bottom;
@@ -416,8 +416,11 @@ export class XYAxis extends SVGWidget {
         currBrush.extent([[0, 0], [width, height]]);
         this.svgBrush
             .attr("transform", "translate(" + this.margin.left + ", " + this.margin.top + ")")
+            .style("height", height)
             .style("display", this.selectionMode() ? null : "none")
             .call(currBrush)
+            .select(".selection")
+            .style("height", height)
             ;
         const handleTypes = this.use2dSelection() ? [] : isHorizontal ? [{ type: "w" }, { type: "e" }] : [{ type: "n" }, { type: "s" }];
         const handlePath = this.svgBrush.selectAll(".handle--custom").data(handleTypes);


### PR DESCRIPTION
* When yAxis is hidden the LHS handle fails to display.
* Resizing can leave the blue selection rectangle at the wrong size.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
