### PR TITLE
fix(demo): Gantt demo missing yAxisType of "time"

### DIFF
--- a/demos/gallery/samples/chart/Gantt/Gantt.js
+++ b/demos/gallery/samples/chart/Gantt/Gantt.js
@@ -8,6 +8,7 @@ new Gantt()
         ["Coding", ["2011-08-09", "2012-09-09"]],
         ["Specs", ["2010-07-09", "2011-08-09"]]
     ])
+    .yAxisType("time")
     .yAxisTypeTimePattern("%Y-%m-%d")
     .render()
     ;


### PR DESCRIPTION
Fixes #3305

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [x] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
