### PR TITLE
fix: Modal now propagates null target to widget

### DIFF
--- a/packages/layout/src/Modal.ts
+++ b/packages/layout/src/Modal.ts
@@ -197,6 +197,16 @@ export class Modal extends HTMLWidget {
         }
         return this.title();
     }
+
+    target(): null | HTMLElement | SVGElement;
+    target(_: null | string | HTMLElement | SVGElement): this;
+    target(_?: null | string | HTMLElement | SVGElement): null | HTMLElement | SVGElement | this {
+        super.target.apply(this, arguments);
+        if (_ === null) {
+            this.widget().target(null);
+        }
+        return this;
+    }
 }
 Modal.prototype._class += " layout_Modal";
 


### PR DESCRIPTION
Fixes #3371

Signed-off-by: Jaman Brundage <jbrundage372@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
