### PR TITLE
fix(eclcc): Syntax Error Parse Issue

### DIFF
--- a/packages/comms/src/clienttools/eclcc.ts
+++ b/packages/comms/src/clienttools/eclcc.ts
@@ -126,7 +126,7 @@ export class EclccErrors extends Errors {
         super(checked);
         if (stdErr && stdErr.length) {
             for (const errLine of stdErr.split(os.EOL)) {
-                let match = /([a-z,A-Z]:\\(?:[-\w\.\d]+\\)*(?:[-\w\.\d]+)?|(?:\/[\w\.\-]+)+)\((\d*),(\d*)\): ?(error|warning|info) C(\d*): ?(.*)/.exec(errLine);
+                let match = /([a-zA-Z]:\\(?:[- \w\.\d]+\\)*(?:[- \w\.\d]+)?|(?:\/[\w\.\-]+)+)\((\d*),(\d*)\) ?: ?(error|warning|info) C(\d*) ?: ?(.*)/.exec(errLine);
                 if (match) {
                     const [, filePath, row, _col, severity, code, _msg] = match;
                     const line: number = +row;

--- a/tests/test-comms/src/clienttools/eclcc.spec.ts
+++ b/tests/test-comms/src/clienttools/eclcc.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { locateClientTools, Version, Workunit } from "@hpcc-js/comms";
+import { EclccErrors, locateClientTools, Version, Workunit } from "@hpcc-js/comms";
 import { isBrowser } from "@hpcc-js/util";
 import { ESP_URL, isTravis } from "../testLib";
 
@@ -15,6 +15,11 @@ function logVersion(build: string): Promise<void> {
             console.log(`${build} => ${version.toString()}`);
         });
     });
+}
+
+function hasError(errStr: string): boolean {
+    const err = new EclccErrors(errStr, []);
+    return err.hasError();
 }
 
 describe("eclcc", function () {
@@ -80,6 +85,12 @@ describe("eclcc", function () {
                     logVersion("comms_5.10.0"),
                     logVersion("comms_5.0.0")
                 ]);
+            });
+
+            it("Syntax Error", function () {
+                expect(hasError(`c:\\Users\\gordon\\Downloads\\VS\\SomeFolder\\VS\\BWR\\BWR_welcome.ecl(1,7): error C3002: syntax error near "'Welcome'" : expected ANY, ASCII, ASSERT, BIG_ENDIAN, CONST, DATASET, DICTIONARY, EBCDIC, GROUPED, IF, LITTLE_ENDIAN, NOCONST, OPT, OUT, PACKED, PATTERN, RECORD, ROW, RULE, SET, type-name, TOKEN, TYPEOF, UNSIGNED, VIRTUAL, <?>, <??>, dataset, identifier, identifier, type name, type name, type name, type name, datarow, function-name, function-name, action, pattern, event, transform-name, '^', '$'`)).to.be.true;
+                expect(hasError(`c:\\Users\\gordon\\Down-loads\\VS\\Some Folder\\VS\\BWR\\BWR_welcome.ecl(1,7): error C3002: syntax error near "'Welcome'" : expected ANY, ASCII, ASSERT, BIG_ENDIAN, CONST, DATASET, DICTIONARY, EBCDIC, GROUPED, IF, LITTLE_ENDIAN, NOCONST, OPT, OUT, PACKED, PATTERN, RECORD, ROW, RULE, SET, type-name, TOKEN, TYPEOF, UNSIGNED, VIRTUAL, <?>, <??>, dataset, identifier, identifier, type name, type name, type name, type name, datarow, function-name, function-name, action, pattern, event, transform-name, '^', '$'`)).to.be.true;
+                expect(hasError("c:\\temp\\test.ecl(7,13) : error C007 : Hello and Welcome")).to.be.true;
             });
         }
     }


### PR DESCRIPTION
Error parsing fails when there is a space in the path.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
