### PR TITLE
fix(build): Remove duplicate d3 packages from bundles

### DIFF
--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/chart/rollup.config.js
+++ b/packages/chart/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/codemirror/rollup.config.js
+++ b/packages/codemirror/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/composite/rollup.config.js
+++ b/packages/composite/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/dgrid/rollup.config.js
+++ b/packages/dgrid/rollup.config.js
@@ -27,21 +27,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/eclwatch/rollup.config.js
+++ b/packages/eclwatch/rollup.config.js
@@ -27,21 +27,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/form/rollup.config.js
+++ b/packages/form/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/graph/rollup.config.js
+++ b/packages/graph/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/html/rollup.config.js
+++ b/packages/html/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/layout/rollup.config.js
+++ b/packages/layout/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/map/rollup.config.js
+++ b/packages/map/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/map/tsconfig.json
+++ b/packages/map/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "rootDir": "./src",
         "outDir": "./lib-umd",
-        "declarationDir": "./types",
+        "declarationDir": "./types"
     },
     "include": [
         "./src/**/*",

--- a/packages/marshaller/rollup.config.js
+++ b/packages/marshaller/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/other/rollup.config.js
+++ b/packages/other/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/phosphor/rollup.config.js
+++ b/packages/phosphor/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/timeline/rollup.config.js
+++ b/packages/timeline/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true

--- a/packages/tree/rollup.config.js
+++ b/packages/tree/rollup.config.js
@@ -25,21 +25,23 @@ export default {
     }],
     plugins: [
         alias({
-            "d3-array": "@hpcc-js/common",
-            "d3-brush": "@hpcc-js/common",
-            "d3-collection": "@hpcc-js/common",
-            "d3-color": "@hpcc-js/common",
-            "d3-dispatch": "@hpcc-js/common",
-            "d3-drag": "@hpcc-js/common",
-            "d3-dsv": "@hpcc-js/common",
-            "d3-ease": "@hpcc-js/common",
-            "d3-format": "@hpcc-js/common",
-            "d3-interpolate": "@hpcc-js/common",
-            "d3-scale": "@hpcc-js/common",
-            "d3-selection": "@hpcc-js/common",
-            "d3-time-format": "@hpcc-js/common",
-            "d3-transition": "@hpcc-js/common",
-            "d3-zoom": "@hpcc-js/common"
+            entries: [
+                { find: "d3-array", replacement: "@hpcc-js/common" },
+                { find: "d3-brush", replacement: "@hpcc-js/common" },
+                { find: "d3-collection", replacement: "@hpcc-js/common" },
+                { find: "d3-color", replacement: "@hpcc-js/common" },
+                { find: "d3-dispatch", replacement: "@hpcc-js/common" },
+                { find: "d3-drag", replacement: "@hpcc-js/common" },
+                { find: "d3-dsv", replacement: "@hpcc-js/common" },
+                { find: "d3-ease", replacement: "@hpcc-js/common" },
+                { find: "d3-format", replacement: "@hpcc-js/common" },
+                { find: "d3-interpolate", replacement: "@hpcc-js/common" },
+                { find: "d3-scale", replacement: "@hpcc-js/common" },
+                { find: "d3-selection", replacement: "@hpcc-js/common" },
+                { find: "d3-time-format", replacement: "@hpcc-js/common" },
+                { find: "d3-transition", replacement: "@hpcc-js/common" },
+                { find: "d3-zoom", replacement: "@hpcc-js/common" }
+            ]
         }),
         nodeResolve({
             preferBuiltins: true


### PR DESCRIPTION
Note:  d3.event needs to be a global singleton

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
