### PR TITLE
fix(ClientTools): Overridden eclccPath should also override envChk

### DIFF
--- a/packages/comms/src/clienttools/eclcc.ts
+++ b/packages/comms/src/clienttools/eclcc.ts
@@ -272,10 +272,10 @@ export class ClientTools {
     protected _args: string[];
     protected _version: Version;
 
-    constructor(eclccPath: string, envchkPath: string, cwd?: string, includeFolders: string[] = [], legacyMode: boolean = false, args: string[] = [], version?: Version) {
+    constructor(eclccPath: string, cwd?: string, includeFolders: string[] = [], legacyMode: boolean = false, args: string[] = [], version?: Version) {
         this.eclccPath = eclccPath;
-        this.envchkPath = envchkPath;
         this.binPath = path.dirname(this.eclccPath);
+        this.envchkPath = path.join(this.binPath, "envchk" + exeExt);
         this.cwd = path.normalize(cwd || this.binPath);
         this.includeFolders = includeFolders;
         this._legacyMode = legacyMode;
@@ -284,7 +284,7 @@ export class ClientTools {
     }
 
     clone(cwd?: string, includeFolders?: string[], legacyMode: boolean = false, args: string[] = []) {
-        return new ClientTools(this.eclccPath, this.envchkPath, cwd, includeFolders, legacyMode, args, this._version);
+        return new ClientTools(this.eclccPath, cwd, includeFolders, legacyMode, args, this._version);
     }
 
     exists(filePath: string) {
@@ -434,19 +434,17 @@ function locateClientToolsInFolder(rootFolder: string, clientTools: ClientTools[
         if (fs.existsSync(hpccSystemsFolder) && fs.statSync(hpccSystemsFolder).isDirectory()) {
             if (os.type() !== "Windows_NT") {
                 const eclccPath = path.join(hpccSystemsFolder, "bin", "eclcc");
-                const envchkPath = path.join(hpccSystemsFolder, "bin", "envchk");
                 if (fs.existsSync(eclccPath)) {
-                    clientTools.push(new ClientTools(eclccPath, fs.existsSync(envchkPath) ? envchkPath : ""));
+                    clientTools.push(new ClientTools(eclccPath));
                 }
             }
             fs.readdirSync(hpccSystemsFolder).forEach((versionFolder) => {
                 const eclccPath = path.join(hpccSystemsFolder, versionFolder, "clienttools", "bin", "eclcc" + exeExt);
-                const envchkPath = path.join(hpccSystemsFolder, versionFolder, "clienttools", "bin", "envchk" + exeExt);
                 if (fs.existsSync(eclccPath)) {
                     const name = path.basename(versionFolder);
                     const version = new Version(name);
                     if (version.exists()) {
-                        clientTools.push(new ClientTools(eclccPath, fs.existsSync(envchkPath) ? envchkPath : ""));
+                        clientTools.push(new ClientTools(eclccPath));
                     }
                 }
             });
@@ -501,7 +499,7 @@ function logEclccPath(eclccPath: string) {
 export function locateClientTools(overridePath: string = "", build: string = "", cwd: string = ".", includeFolders: string[] = [], legacyMode: boolean = false): Promise<ClientTools> {
     if (overridePath && fs.existsSync(overridePath)) {
         logEclccPath(overridePath);
-        return Promise.resolve(new ClientTools(overridePath, "", cwd, includeFolders, legacyMode));
+        return Promise.resolve(new ClientTools(overridePath, cwd, includeFolders, legacyMode));
     }
     return locateAllClientTools().then((allClientToolsCache2) => {
         if (!allClientToolsCache2.length) {


### PR DESCRIPTION
Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
