### PR TITLE
fix(dgrid):  Typo in multiSelect property

### DIFF
--- a/packages/dgrid/src/Common.ts
+++ b/packages/dgrid/src/Common.ts
@@ -32,7 +32,14 @@ export class Common extends HTMLWidget {
     @publish(false, "boolean", "Default 'sort by' descending", null, { disable: self => !self.sortBy() })
     sortByDescending: publish<this, boolean>;
     @publish(false, "boolean", "Multiple Selection")
-    mulitSelect: publish<this, boolean>;
+    multiSelect: publish<this, boolean>;
+
+    //  Backward Compatibility
+    mulitSelect(): boolean;
+    mulitSelect(_?: boolean): this;
+    mulitSelect(_?: boolean): this | boolean {
+        return this.multiSelect.apply(this, arguments);
+    }
 
     protected formatSortBy(): [{ property: string, descending: boolean }] | undefined {
         const idx = this.columns().indexOf(this.sortBy());
@@ -63,12 +70,12 @@ export class Common extends HTMLWidget {
         if (!this._dgrid || this._prevPaging !== this.pagination() ||
             this._prevSortBy !== this.sortBy() ||
             this._prevSortByDescending !== this.sortByDescending() ||
-            this._prevMultiSelect !== this.mulitSelect()) {
+            this._prevMultiSelect !== this.multiSelect()) {
 
             this._prevPaging = this.pagination();
             this._prevSortBy = this.sortBy();
             this._prevSortByDescending = this.sortByDescending();
-            this._prevMultiSelect = this.mulitSelect();
+            this._prevMultiSelect = this.multiSelect();
             if (this._dgrid) {
                 this._dgrid.destroy();
                 this._dgridDiv = element.append("div")
@@ -79,7 +86,7 @@ export class Common extends HTMLWidget {
                 columns: this._columns,
                 collection: this._store,
                 sort: this.formatSortBy(),
-                selectionMode: this.mulitSelect() ? "extended" : "single",
+                selectionMode: this.multiSelect() ? "extended" : "single",
                 deselectOnRefresh: true,
                 cellNavigation: false,
                 pagingLinks: 1,


### PR DESCRIPTION
Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
