### PR TITLE
fix(chart): Heat Chart palette issue

### DIFF
--- a/packages/chart/src/Heat.ts
+++ b/packages/chart/src/Heat.ts
@@ -66,6 +66,8 @@ export class Heat extends XYAxis {
                 gradient[i / count] = this._palette((reverse ? count - i : i) / count, 0, 1);
             }
             this._heat.gradient(gradient);
+        } else {
+            this._heat.gradient(this._heat.defaultGradient);
         }
 
         this._heat.resize();


### PR DESCRIPTION
Once a palette is switched, it is impossible to go back to the default.

Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
