### PR TITLE
fix(eclcc):  locateClientTools missing args option.

### DIFF
--- a/packages/comms/src/clienttools/eclcc.ts
+++ b/packages/comms/src/clienttools/eclcc.ts
@@ -496,10 +496,10 @@ function logEclccPath(eclccPath: string) {
     }
 }
 
-export function locateClientTools(overridePath: string = "", build: string = "", cwd: string = ".", includeFolders: string[] = [], legacyMode: boolean = false): Promise<ClientTools> {
+export function locateClientTools(overridePath: string = "", build: string = "", cwd: string = ".", includeFolders: string[] = [], legacyMode: boolean = false, args: string[] = []): Promise<ClientTools> {
     if (overridePath && fs.existsSync(overridePath)) {
         logEclccPath(overridePath);
-        return Promise.resolve(new ClientTools(overridePath, cwd, includeFolders, legacyMode));
+        return Promise.resolve(new ClientTools(overridePath, cwd, includeFolders, legacyMode, args));
     }
     return locateAllClientTools().then((allClientToolsCache2) => {
         if (!allClientToolsCache2.length) {
@@ -512,10 +512,10 @@ export function locateClientTools(overridePath: string = "", build: string = "",
             const ctVersion = ct.versionSync();
             if (!latest) latest = ct;
             if (!bestMajor && buildVersion.major === ctVersion.major) bestMajor = ct;
-            if (buildVersion.major === ctVersion.major && buildVersion.minor === ctVersion.minor) return ct.clone(cwd, includeFolders, legacyMode);
+            if (buildVersion.major === ctVersion.major && buildVersion.minor === ctVersion.minor) return ct.clone(cwd, includeFolders, legacyMode, args);
         }
         const best: ClientTools = bestMajor || latest!;
         logEclccPath(best.eclccPath);
-        return best.clone(cwd, includeFolders, legacyMode);
+        return best.clone(cwd, includeFolders, legacyMode, args);
     });
 }

--- a/tests/test-comms/.vscode/tasks.json
+++ b/tests/test-comms/.vscode/tasks.json
@@ -1,19 +1,16 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
-            "type": "typescript",
-            "tsconfig": "tsconfig.json",
-            "option": "watch",
+            "type": "npm",
+            "script": "compile-umd-watch",
             "problemMatcher": [
                 "$tsc-watch"
             ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
+            "group": "build",
+            "label": "npm: compile-umd-watch",
+            "detail": "npm run compile-umd -- -w",
+            "isBackground": true
         }
     ]
 }

--- a/tests/test-comms/package.json
+++ b/tests/test-comms/package.json
@@ -33,7 +33,7 @@
         "watch": "npm-run-all compile-es6 -p compile-es6-watch bundle-watch",
         "build": "npm run compile-es6 && npm run compile-umd && npm run bundle",
         "test": "npm run test:node",
-        "test:node": "./node_modules/.bin/mocha lib-umd/index.spec.js --exit --reporter spec",
+        "test:node": "./node_modules/.bin/mocha lib-umd/index.node.spec.js --exit --reporter spec",
         "test:chrome": "mocha-chrome --chrome-flags \"[\\\"--allow-file-access-from-files\\\"]\" ./test.html"
     }
 }

--- a/tests/test-comms/src/index.node.spec.ts
+++ b/tests/test-comms/src/index.node.spec.ts
@@ -1,0 +1,3 @@
+import "./index.spec";
+
+import "./clienttools/eclcc.spec";

--- a/tests/test-comms/src/index.spec.ts
+++ b/tests/test-comms/src/index.spec.ts
@@ -15,5 +15,3 @@ import "./ecl/xsdParser.spec";
 import "./services/wsDFU.spec";
 import "./services/wsTopology.spec";
 import "./services/wsWorkunits.spec";
-
-import "./clienttools/eclcc.spec";

--- a/tests/test-comms/tsconfig.json
+++ b/tests/test-comms/tsconfig.json
@@ -18,6 +18,7 @@
       "es2015.iterable"
     ],
     "types": [
+      "node",
       "chai",
       "mocha"
     ]


### PR DESCRIPTION
Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
