### PR TITLE
fix:  fetchTargetClusters can fail in some environments

### DIFF
--- a/packages/comms/src/ecl/topology.ts
+++ b/packages/comms/src/ecl/topology.ts
@@ -69,7 +69,7 @@ export class Topology extends StateObject<TopologyStateEx, TopologyStateEx> impl
     fetchTargetClusters(): Promise<TargetCluster[]> {
         return this.connection.TpTargetClusterQuery({ Type: "ROOT" }).then(response => {
             this.set({
-                TargetClusters: response.TpTargetClusters.TpTargetCluster
+                TargetClusters: response.TpTargetClusters?.TpTargetCluster ?? []
             });
             return this.CTargetClusters;
         });


### PR DESCRIPTION
Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
