### PR TITLE
feat(comms): Separate Cost property for DFUQuery response for access and at rest costs

### DIFF
--- a/packages/comms/src/services/wsDFU.ts
+++ b/packages/comms/src/services/wsDFU.ts
@@ -1555,7 +1555,8 @@ export namespace WsDfu {
         KeyType: string;
         NumOfSubfiles: number;
         Accessed: string;
-        Cost?: number;
+        AtRestCost?: number;
+        AccessCost?: number;
     }
 
     export interface Superfiles {
@@ -2821,7 +2822,7 @@ export namespace WsDfu {
 export class DFUService extends Service {
 
     constructor(optsConnection: IOptions | IConnection) {
-        super(optsConnection, "WsDfu", "1.60");
+        super(optsConnection, "WsDfu", "1.62");
     }
 
     DFUQuery(request: WsDfu.DFUQueryRequest): Promise<WsDfu.DFUQueryResponse> {


### PR DESCRIPTION
Signed-off-by: Jeremy Clements <jeremy.clements@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
