### PR TITLE
fix(comms): In utils wsdlToTs code generator, use namespace as defined in the WSDL

### DIFF
--- a/packages/comms/utils/index.ts
+++ b/packages/comms/utils/index.ts
@@ -153,10 +153,12 @@ wsdlToTs(args.url)
         const bindings = wsdl.definitions.bindings;
         const wsdlNS = wsdl.definitions.$targetNamespace;
         let namespace = "";
+        let origNS = "";
         for (const ns in descr) {
+            origNS = ns;
             namespace = changeCase(ns, Case.PascalCase);
             const service = descr[ns];
-            printDbg("namespace: ", namespace, "\n");
+            printDbg("namespace: ", origNS, "\n");
             for (const op in service) {
                 printDbg("binding: ", changeCase(op, Case.PascalCase), "\n");
                 const binding = service[op];
@@ -228,7 +230,7 @@ wsdlToTs(args.url)
         }
 
         const serviceVersion = `v${methods[0]?.version}` ?? "";
-        const finalPath = path.join(outDir, namespace, serviceVersion);
+        const finalPath = path.join(outDir, origNS, serviceVersion);
         const relativePath = path.relative(path.join(cwd, finalPath), path.join(cwd, "./src")).replace(/\\/g, "/");
         lines.unshift("\n\n");
         lines.unshift(`import { Service } from "${relativePath}/espConnection";`);
@@ -236,7 +238,7 @@ wsdlToTs(args.url)
 
         if (methods.length > 0) {
             lines.push("constructor(optsConnection: IOptions | IConnection) {");
-            lines.push(`super(optsConnection, "${namespace}", "${methods[0].version}");`);
+            lines.push(`super(optsConnection, "${origNS}", "${methods[0].version}");`);
             lines.push("}");
             lines.push("\n\n");
 
@@ -253,7 +255,7 @@ wsdlToTs(args.url)
             console.log(lines.join("\n").replace(/\n\n\n/g, "\n"));
         } else {
             mkdirp(finalPath).then(() => {
-                const tsFile = path.join(finalPath, namespace + ".ts");
+                const tsFile = path.join(finalPath, origNS + ".ts");
                 writeFile(tsFile, lines.join("\n").replace(/\n\n\n/g, "\n"), (err) => {
                     if (err) throw err;
                 })


### PR DESCRIPTION

Signed-off-by: Jeremy Clements <jeremy.clements@lexisnexisrisk.com>

The namespace as defined in the WSDL will be used for both the file path / name of generated files & as the service name passed into the ...Service constructor

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
