### PR TITLE
fix(comms): add LogAccessType enum to exports in wsLogaccess & include wsDali in exported comms services

### DIFF
--- a/packages/comms/src/index-common.ts
+++ b/packages/comms/src/index-common.ts
@@ -5,6 +5,7 @@ export * from "./services/wsAccess";
 export * from "./services/wsAccount";
 export * from "./services/wsCloud";
 export * from "./services/wsCodesign";
+export * from "./services/wsDali";
 export * from "./services/wsDFU";
 export * from "./services/wsDFUXRef";
 export * from "./services/wsEcl";

--- a/packages/comms/src/services/wsLogaccess.ts
+++ b/packages/comms/src/services/wsLogaccess.ts
@@ -1,7 +1,7 @@
-import { LogaccessServiceBase, WsLogaccess } from "./wsdl/ws_logaccess/v1/ws_logaccess";
+import { LogaccessServiceBase, WsLogaccess, LogAccessType } from "./wsdl/ws_logaccess/v1/ws_logaccess";
 
 export {
-    WsLogaccess
+    WsLogaccess, LogAccessType
 };
 
 export class LogaccessService extends LogaccessServiceBase {


### PR DESCRIPTION
Signed-off-by: Jeremy Clements <jeremy.clements@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
