### PR TITLE
fix: Initialise editor to text content

### DIFF
--- a/components/editor/src/codemirror.md
+++ b/components/editor/src/codemirror.md
@@ -21,6 +21,27 @@
   </hpcc-vitepress>
 </ClientOnly>
 
+---
+
+<ClientOnly>
+  <hpcc-vitepress preview_border="0px" preview_height_ratio=0.5 style="width:100%;height:400px">
+    <hpcc-codemirror mode="json" theme="dark" style="width:100%;height:100%">
+      {
+        "aaa":123, 
+        "bbb":"ddd", 
+        "c":3, 
+        "d":true
+      }
+     </hpcc-codemirror>
+    <script type="module">
+      import "@hpcc-js/wc-editor";
+      setTimeout(()=>{
+        document.querySelector('hpcc-codemirror').text = "Hello and Welcome!";
+      }, 3000);
+    </script>
+  </hpcc-vitepress>
+</ClientOnly>
+
 ::: tip
 See [Getting Started](../../../README) for details on how to include @hpcc-js/codemirror in your application
 :::

--- a/components/editor/src/codemirror.ts
+++ b/components/editor/src/codemirror.ts
@@ -10,7 +10,9 @@ import { oneDarkTheme, oneDarkHighlightStyle } from "@codemirror/theme-one-dark"
 
 const template = html<HPCCCodemirrorElement>`\
 <div ${ref("_div")}>
-</div>`;
+</div>
+<slot ${ref("_slot")}></slot>
+`;
 
 const styles = `\
 ${display("inline-block")}
@@ -59,10 +61,13 @@ export class HPCCCodemirrorElement extends HPCCResizeElement {
     private _cmJavaScript = cmJavaScript();
 
     _div: HTMLDivElement;
+    _slot: HTMLSlotElement;
+
     protected _view: EditorView;
 
     constructor() {
         super();
+        this._text = this._slot.assignedNodes().map(n => n.textContent).join("\n").trim();
     }
 
     protected extensions(): Extension[] {


### PR DESCRIPTION
Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
