### PR TITLE
GH-4072 Graph2 add support for image icons

### DIFF
--- a/packages/graph/src/__tests__/data.ts
+++ b/packages/graph/src/__tests__/data.ts
@@ -5,8 +5,8 @@ import { Edge } from "../Edge";
 export function genData2() {
     return {
         vertices: [
-            ["a", "myriel@gmail.com", "fa-at", false, false, false, "fa-plus"],
-            [1, "Napoleon", "fa-user-o", true, true, true, "fa-plus"],
+            ["a", "myriel@gmail.com", "fa-at", false, false, false, "fa-plus", "https://th.bing.com/th/id/OIP.3FhSHq5xMXMDZ7gYBZ1nzQHaHa?w=210&h=210&c=7&r=0&o=5&pid=1.7"],
+            [1, "Napoleon", "fa-user-o", true, true, true, "fa-plus", "https://th.bing.com/th/id/OIP.3FhSHq5xMXMDZ7gYBZ1nzQHaHa?w=210&h=210&c=7&r=0&o=5&pid=1.7"],
             [2, "Mlle.Baptistine", "fa-user-o"],
             [3, "Mme.Magloire", "fa-user-o"],
             [4, "CountessdeLo", "fa-user-o"],

--- a/packages/graph/src/__tests__/index.ts
+++ b/packages/graph/src/__tests__/index.ts
@@ -1,1 +1,1 @@
-export { Test4 as Test } from "./test4";
+export { Test2 as Test } from "./test2";

--- a/packages/graph/src/__tests__/test2.ts
+++ b/packages/graph/src/__tests__/test2.ts
@@ -43,8 +43,9 @@ export class Test2 extends DataGraph {
                 imageCharFill: "white"
             }])
 
-            .vertexColumns(["id", "label", "fachar", "centroid", "ann1", "ann2", "expandedFAChar"])
+            .vertexColumns(["id", "label", "fachar", "centroid", "ann1", "ann2", "expandedFAChar", "imageUrl"])
             .vertexCentroidColumn("centroid")
+            .vertexImageUrlColumn("imageUrl")
             .vertexFACharColumn("fachar")
             .vertexIDColumn("id")
             .vertexLabelColumn("label")

--- a/packages/graph/src/graph2/dataGraph.ts
+++ b/packages/graph/src/graph2/dataGraph.ts
@@ -58,6 +58,10 @@ export class DataGraph extends Graph2 {
     vertexLabelColumn: publish<this, string>;
     @publish("", "set", "Vertex centroid column (boolean)", function (this: DataGraph) { return this.vertexColumns(); }, { optional: true })
     vertexCentroidColumn: publish<this, string>;
+    @publish("", "string", "Vertex default image url")
+    vertexImageUrl: publish<this, string>;
+    @publish("", "set", "Vertex image url column", function (this: DataGraph) { return this.vertexColumns(); }, { optional: true })
+    vertexImageUrlColumn: publish<this, string>;
     @publish("?", "string", "Vertex default FAChar")
     vertexFAChar: publish<this, string>;
     @publish("", "set", "Vertex FAChar column", function (this: DataGraph) { return this.vertexColumns(); }, { optional: true })
@@ -170,6 +174,7 @@ export class DataGraph extends Graph2 {
         const idIdx = this.indexOf(columns, this.vertexIDColumn(), "id");
         const labelIdx = this.indexOf(columns, this.vertexLabelColumn(), "label");
         const centroidIdx = this.indexOf(columns, this.vertexCentroidColumn(), "centroid");
+        const imageUrlIdx = this.indexOf(columns, this.vertexImageUrlColumn(), "faChar");
         const faCharIdx = this.indexOf(columns, this.vertexFACharColumn(), "faChar");
         const vertexTooltipIdx = this.indexOf(columns, this.vertexTooltipColumn(), "tooltip");
         const annotationIdxs = annotationColumns.map(ac => this.indexOf(columns, ac.columnID(), ""));
@@ -184,6 +189,7 @@ export class DataGraph extends Graph2 {
                 origData: toJsonObj(v, columns),
                 centroid: !!v[centroidIdx],
                 icon: {
+                    imageUrl: "" + (v[imageUrlIdx] || this.vertexImageUrl()),
                     imageChar: "" + (v[faCharIdx] || this.vertexFAChar())
                 },
                 annotationIDs,

--- a/packages/react/src/icon.tsx
+++ b/packages/react/src/icon.tsx
@@ -1,5 +1,6 @@
 import { Palette } from "@hpcc-js/common";
 import * as React from "@hpcc-js/preact-shim";
+import { Image } from "./image";
 import { ImageChar } from "./ImageChar";
 import { Shape } from "./shape";
 
@@ -11,6 +12,7 @@ export interface Icon {
     fill?: string;
     stroke?: string;
     strokeWidth?: number;
+    imageUrl?: string;
     imageFontFamily?: string;
     imageChar?: string;
     imageCharFill?: string;
@@ -27,6 +29,7 @@ export const Icon: React.FunctionComponent<Icon> = ({
     fill,
     stroke,
     strokeWidth = 0,
+    imageUrl = "",
     imageFontFamily = "FontAwesome",
     imageChar = "",
     imageCharFill = Palette.textColor(fill),
@@ -47,15 +50,23 @@ export const Icon: React.FunctionComponent<Icon> = ({
             shapeRendering={shapeRendering}
             cornerRadius={cornerRadius}
         />
-        <ImageChar
-            x={xOffset}
-            y={yOffset}
-            height={height - padding}
-            fontFamily={imageFontFamily}
-            char={imageChar}
-            fill={imageCharFill}
-            font-weight={400}
-        ></ImageChar>
+        {imageUrl ?
+            <Image
+                href={imageUrl}
+                x={xOffset}
+                y={yOffset}
+                height={height - padding}
+            ></Image> :
+            <ImageChar
+                x={xOffset}
+                y={yOffset}
+                height={height - padding}
+                fontFamily={imageFontFamily}
+                char={imageChar}
+                fill={imageCharFill}
+                font-weight={400}
+            ></ImageChar>
+        }
     </>;
 };
 
@@ -72,13 +83,13 @@ export const Icons: React.FunctionComponent<Icons> = ({
 }) => {
     const IconComponents = icons.map(cat => {
         return <g
-                key={cat.id}
-                id={cat.id}
-            >
-                <Icon
-                    {...cat}
-                />
-            </g>;
+            key={cat.id}
+            id={cat.id}
+        >
+            <Icon
+                {...cat}
+            />
+        </g>;
     });
     return <>{IconComponents}</>;
 };

--- a/packages/react/src/image.tsx
+++ b/packages/react/src/image.tsx
@@ -1,0 +1,25 @@
+import * as React from "@hpcc-js/preact-shim";
+
+interface Image {
+    href: string;
+    x?: number;
+    y?: number;
+    height?: number;
+    yOffset?: number;
+}
+
+export const Image: React.FunctionComponent<Image> = ({
+    href,
+    x,
+    y = 0,
+    height = 12
+}) => {
+
+    return <image
+        href={href}
+        x={x - height / 2}
+        y={y - height / 2}
+        width={height}
+        height={height}
+    ></image>;
+};

--- a/packages/react/src/vertex3.tsx
+++ b/packages/react/src/vertex3.tsx
@@ -42,7 +42,7 @@ export const Vertex3: React.FunctionComponent<Vertex3Props> = ({
     annotations = [],
     cornerRadius = 3,
     icon = {},
-    subText = {},
+    subText = { text: "" },
     showLabel = true,
     noLabelRadius = 5,
     expansionIcon,


### PR DESCRIPTION
DataGraph:
 * vertexImageUrl
 * vertexImageUrlColumn

Icon:
 * imageUrl

Fixes #4072

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
