### PR TITLE
fix(comms): wsLogaccess GetLogs fix an incorrect boolean operator

### DIFF
--- a/packages/comms/src/services/wsLogaccess.ts
+++ b/packages/comms/src/services/wsLogaccess.ts
@@ -133,7 +133,7 @@ export class LogaccessService extends LogaccessServiceBase {
                     BinaryLogFilter: [{
                         leftFilter: {
                             LogCategory: WsLogaccess.LogAccessType.All,
-                        } as WsLogaccess.leftFilter,
+                        },
                     } as WsLogaccess.BinaryLogFilter]
                 }
             },
@@ -178,7 +178,7 @@ export class LogaccessService extends LogaccessServiceBase {
                     }
                     if (i === filters.length - 1) {
                         binaryLogFilter.Operator = operator;
-                        binaryLogFilter.rightFilter = filter;
+                        binaryLogFilter.rightFilter = filter as WsLogaccess.rightFilter;
                     } else {
                         binaryLogFilter.Operator = operator;
                         binaryLogFilter.rightBinaryFilter = {
@@ -189,28 +189,31 @@ export class LogaccessService extends LogaccessServiceBase {
                         binaryLogFilter = binaryLogFilter.rightBinaryFilter.BinaryLogFilter[0];
                     }
                 } else {
-                    binaryLogFilter.leftFilter = filter;
+                    binaryLogFilter.leftFilter = filter as WsLogaccess.leftFilter;
                 }
             });
         } else {
             delete getLogsRequest.Filter.leftBinaryFilter;
             getLogsRequest.Filter.leftFilter = {
                 LogCategory: WsLogaccess.LogAccessType.All
-            };
+            } as WsLogaccess.leftFilter;
             if (filters[0]?.SearchField) {
                 getLogsRequest.Filter.leftFilter = {
                     LogCategory: filters[0]?.LogCategory,
                     SearchField: filters[0]?.SearchField,
                     SearchByValue: filters[0]?.SearchByValue
-                }
+                };
             }
             if (filters[1]?.SearchField) {
                 getLogsRequest.Filter.Operator = WsLogaccess.LogAccessFilterOperator.AND;
+                if (filters[0].SearchField === filters[1].SearchField) {
+                    getLogsRequest.Filter.Operator = WsLogaccess.LogAccessFilterOperator.OR;
+                }
                 getLogsRequest.Filter.rightFilter = {
                     LogCategory: filters[0]?.LogCategory,
                     SearchField: filters[1]?.SearchField,
                     SearchByValue: filters[1]?.SearchByValue
-                }
+                };
             }
         }
 


### PR DESCRIPTION
Fixing the scenario where there is one filter with two separate values, eg class = 'ERR' && class = 'WRN'

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
