### PR TITLE
fix(comms): dgrid-shim gridHelper reset huge total to sensible number

### DIFF
--- a/packages/dgrid-shim/src/gridHelper.ts
+++ b/packages/dgrid-shim/src/gridHelper.ts
@@ -3,6 +3,7 @@ import * as DGridPagination from "dgrid/extensions/Pagination";
 import * as Tooltip from "dijit/Tooltip";
 import * as declare from "dojo/_base/declare";
 import * as query from "dojo/_base/query";
+import * as domClass from "dojo/dom-class";
 
 export const GridHelper = declare(null, {
     allowTextSelection: true,
@@ -114,6 +115,9 @@ export const GridHelper = declare(null, {
     */
 });
 
+//defined as 9223372036854775807 in ESP, but TS complains of loss of precision
+const UNKNOWN_NUM_ROWS = 9223372036854775000;
+
 export const Pagination = declare([DGridPagination], {
     refresh(options?) {
         const self = this;
@@ -127,5 +131,18 @@ export const Pagination = declare([DGridPagination], {
             self._emitRefreshComplete();
             return results;
         });
+    },
+
+    _updateNavigation: function (total) {
+        this.inherited(arguments);
+
+        if (total >= UNKNOWN_NUM_ROWS) {
+            query(".dgrid-page-link:last-child", this.paginationNavigationNode).forEach(function (link) {
+                domClass.toggle(link, "dgrid-page-disabled", true);
+                link.tabIndex = -1;
+            });
+            const pageText = query(".dgrid-status", this.paginationNode)[0];
+            pageText.innerText = pageText?.innerText?.replace(/[0-9]{7,}/, "unknown");
+        }
     }
 });


### PR DESCRIPTION
when the value returned from ESP is UNKNOWN_NUM_ROWS

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
