### PR TITLE
fix(comms): WsMachine Target Cluster sizes are in KB

### DIFF
--- a/packages/comms/src/services/wsMachine.ts
+++ b/packages/comms/src/services/wsMachine.ts
@@ -51,7 +51,8 @@ export class MachineService extends MachineServiceBase {
                         const DiskUsages: WsMachineEx.DiskUsage[] = mu.DiskUsages && mu.DiskUsages.DiskUsage ? mu.DiskUsages.DiskUsage.map(du => {
                             return {
                                 ...du,
-                                Total: du.InUse + du.Available,
+                                InUse: du.InUse * 1024,
+                                Total: (du.InUse + du.Available) * 1024,
                                 PercentUsed: 100 - du.PercentAvailable
                             };
                         }) : [];


### PR DESCRIPTION
ESP typically returns any sizes in bytes, but WsMachine returns these disk usage sizes in kilobytes, so multiply by 1024.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
