### PR TITLE
fix(dgrid-shim): max page when pagination counts are unknown

### DIFF
--- a/packages/dgrid-shim/src/gridHelper.ts
+++ b/packages/dgrid-shim/src/gridHelper.ts
@@ -139,6 +139,9 @@ export const Pagination = declare([DGridPagination], {
         if (total >= UNKNOWN_NUM_ROWS) {
             query(".dgrid-page-link:last-child", this.paginationNavigationNode).forEach(function (link) {
                 domClass.toggle(link, "dgrid-page-disabled", true);
+                if (parseInt(link.innerText, 10) >= UNKNOWN_NUM_ROWS) {
+                    link.innerText = "???";
+                }
                 link.tabIndex = -1;
             });
             const pageText = query(".dgrid-status", this.paginationNode)[0];


### PR DESCRIPTION
When pagination counts are unknown, change the text of the maximum page link to reflect this, rather than the unreasonably large UNKNOWN_NUM_ROWS returned by ESP

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
