### PR TITLE
fix(comms): correct wsdl generated services enum values

### DIFF
--- a/packages/comms/utils/index.ts
+++ b/packages/comms/utils/index.ts
@@ -102,7 +102,7 @@ function parseEnum(enumString: string, enumEl) {
                 });
                 return `${memberName} = ${member}`;
             }
-            return `${member} = "${member}"`;
+            return `${member} = "${v}"`;
         })
     };
 }


### PR DESCRIPTION
The values of enums shouldn't be modified from how they exist in the WSDL. In this case, they were being written with white space removed. For example, "Allqueries" (incorrect) instead of "All queries" (correct), which is used as values of the SuspendedFilter request parameter of WsWorkunits.WUListQueries

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
