### PR TITLE
fix(comms): change LogCategory filter based upon searchField

### DIFF
--- a/packages/comms/src/services/wsLogaccess.ts
+++ b/packages/comms/src/services/wsLogaccess.ts
@@ -36,7 +36,7 @@ export const enum LogType {
 export const enum TargetAudience {
     Operator = "OPR",
     User = "USR",
-    Programmer = "PRG",
+    Programmer = "PRO",
     Audit = "ADT"
 }
 
@@ -112,18 +112,24 @@ export class LogaccessService extends LogaccessServiceBase {
             if (key in columnMap) {
                 searchField = columnMap[key];
             }
+            let logCategory = WsLogaccess.LogAccessType.ByFieldName;
             if (searchField) {
+                switch (searchField) {
+                    case "hpcc.log.audience":
+                        logCategory = WsLogaccess.LogAccessType.ByTargetAudience;
+                        break;
+                }
                 if (Array.isArray(request[key])) {
                     request[key].forEach(value => {
                         filters.push({
-                            LogCategory: WsLogaccess.LogAccessType.ByFieldName,
+                            LogCategory: logCategory,
                             SearchField: searchField,
                             SearchByValue: value
                         });
                     });
                 } else {
                     filters.push({
-                        LogCategory: WsLogaccess.LogAccessType.ByFieldName,
+                        LogCategory: logCategory,
                         SearchField: searchField,
                         SearchByValue: request[key]
                     });
@@ -173,7 +179,7 @@ export class LogaccessService extends LogaccessServiceBase {
                     getLogsRequest.Filter.Operator = WsLogaccess.LogAccessFilterOperator.OR;
                 }
                 getLogsRequest.Filter.rightFilter = {
-                    LogCategory: filters[0]?.LogCategory,
+                    LogCategory: filters[1]?.LogCategory,
                     SearchField: filters[1]?.SearchField,
                     SearchByValue: filters[1]?.SearchByValue
                 };


### PR DESCRIPTION
The filter passed to WsLogaccess.GetLogs should change the "LogCategory" request parameter based upon the field that is being searched. (eg, HPCC-31896)

Also, corrects TargetAudience.Programmer value to "PRO", see https://github.com/hpcc-systems/HPCC-Platform/blob/master/esp/scm/ws_logaccess.ecm#L145

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
