### PR TITLE
fix(comms): wsLogaccess GetLogs results not sorted by default

### DIFF
--- a/packages/comms/src/services/wsLogaccess.ts
+++ b/packages/comms/src/services/wsLogaccess.ts
@@ -103,7 +103,14 @@ export class LogaccessService extends LogaccessServiceBase {
             LogLineStartFrom: request.LogLineStartFrom ?? 0,
             LogLineLimit: request.LogLineLimit ?? 100,
             SelectColumnMode: WsLogaccess.LogSelectColumnMode.DEFAULT,
-            Format: "JSON"
+            Format: "JSON",
+            SortBy: {
+                SortCondition: [{
+                    BySortType: WsLogaccess.SortColumType.ByDate,
+                    ColumnName: "",
+                    Direction: 0
+                }]
+            }
         };
 
         const filters: WsLogaccess.leftFilter[] = [];


### PR DESCRIPTION
logs returned by the log engine don't seem to use a default sort, so some default should be supplied in the request

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
