### PR TITLE
fix: Custom cell render fails with plain string

### DIFF
--- a/packages/dgrid/src/Table.ts
+++ b/packages/dgrid/src/Table.ts
@@ -58,7 +58,7 @@ export class ColumnFormat extends PropertyExt {
                 d3Select(cellElement)
                     .style("background", background)
                     .style("color", Palette.textColor(background))
-                    .text(cellText.html ? cellText.html : cell)
+                    .text(cellText?.html ?? cellText ?? cell)
                     ;
             };
         }
@@ -184,7 +184,7 @@ export class Table extends Common {
                     }
                 }
             }
-            this._dgrid.set("columns", this._columns);
+            this._dgrid.set("columns", this._columns.filter(col => !col.hidden));
             this._colsRefresh = false;
         }
         if (this._colsRefresh || this._dataRefresh) {


### PR DESCRIPTION
Cell of width zero should never render.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
