### PR TITLE
chore(comms): bump WsAccount wsdl to 1.06

### DIFF
--- a/packages/comms/src/services/wsAccount.ts
+++ b/packages/comms/src/services/wsAccount.ts
@@ -1,105 +1,11 @@
-import { IConnection, IOptions } from "../connection";
-import { ESPConnection, ESPExceptions } from "../espConnection";
+import { AccountServiceBase, WsAccount } from "./wsdl/ws_account/v1.06/ws_account";
+import { ESPExceptions } from "../espConnection";
 
-/*
-    Response structures generated via:
-    * http://localhost:8010/Ws_Account/?reqjson_
-    * http://localhost:8010/Ws_Account/?respjson_
-    * http://json2ts.com/
-*/
-export namespace WsAccount {
+export {
+    WsAccount
+};
 
-    export interface MyAccountRequest {
-    }
-
-    export interface WsAccountPingRequest {
-    }
-
-    export interface UpdateUserRequest {
-        username: string;
-        oldpass: string;
-        newpass1: string;
-        newpass2: string;
-    }
-
-    export interface UpdateUserInputRequest {
-    }
-
-    export interface VerifyUserRequest {
-        application: string;
-        version: string;
-    }
-
-    export interface Exception {
-        Code: string;
-        Audience: string;
-        Source: string;
-        Message: string;
-    }
-
-    export interface Exceptions {
-        Source: string;
-        Exception: Exception[];
-    }
-
-    export interface MyAccountResponse {
-        Exceptions: Exceptions;
-        username: string;
-        firstName: string;
-        lastName: string;
-        passwordExpiration: string;
-        passwordDaysRemaining: number;
-        passwordExpirationWarningDays: number;
-        employeeID: string;
-        distinguishedName: string;
-        accountType: string;
-        passwordNeverExpires: boolean;
-        passwordIsExpired: boolean;
-        accountStatus: number;
-    }
-
-    export interface WsAccountPingResponse {
-    }
-
-    export interface UpdateUserResponse {
-        Exceptions: Exceptions;
-        retcode: number;
-        message: string;
-    }
-
-    export interface UpdateUserInputResponse {
-        Exceptions: Exceptions;
-        username: string;
-    }
-
-    export interface VerifyUserResponse {
-        Exceptions: Exceptions;
-        retcode: number;
-    }
-}
-
-export class AccountService {
-    private _connection: ESPConnection;
-
-    constructor(optsConnection: IOptions | IConnection) {
-        this._connection = new ESPConnection(optsConnection, "Ws_Account", "1.05");
-    }
-
-    connectionOptions(): IOptions {
-        return this._connection.opts();
-    }
-
-    MyAccount(request: WsAccount.MyAccountRequest): Promise<WsAccount.MyAccountResponse> {
-        return this._connection.send("MyAccount", request);
-    }
-
-    UpdateUser(request: WsAccount.UpdateUserRequest): Promise<WsAccount.UpdateUserResponse> {
-        return this._connection.send("UpdateUser", request);
-    }
-
-    UpdateUserInput(request: WsAccount.UpdateUserInputRequest): Promise<WsAccount.UpdateUserInputResponse> {
-        return this._connection.send("UpdateUserInput", request);
-    }
+export class AccountService extends AccountServiceBase {
 
     VerifyUser(request: WsAccount.VerifyUserRequest): Promise<WsAccount.VerifyUserResponse> {
         return this._connection.send("VerifyUser", request)
@@ -117,4 +23,5 @@ export class AccountService {
                 throw e;
             });
     }
+
 }

--- a/packages/comms/src/services/wsdl/ws_account/v1.06/ws_account.ts
+++ b/packages/comms/src/services/wsdl/ws_account/v1.06/ws_account.ts
@@ -1,0 +1,109 @@
+import { IConnection, IOptions } from "../../../../connection";
+import { Service } from "../../../../espConnection";
+
+export namespace WsAccount {
+
+    export type int = number;
+
+    export interface MyAccountRequest {
+
+    }
+
+    export interface Exception {
+        Code: string;
+        Audience: string;
+        Source: string;
+        Message: string;
+    }
+
+    export interface Exceptions {
+        Source: string;
+        Exception: Exception[];
+    }
+
+    export interface MyAccountResponse {
+        Exceptions: Exceptions;
+        username: string;
+        firstName: string;
+        lastName: string;
+        passwordExpiration: string;
+        passwordDaysRemaining: int;
+        passwordExpirationWarningDays: int;
+        employeeID: string;
+        distinguishedName: string;
+        accountType: string;
+        passwordNeverExpires: boolean;
+        passwordIsExpired: boolean;
+        CanUpdatePassword: boolean;
+        accountStatus: int;
+    }
+
+    export interface ws_accountPingRequest {
+
+    }
+
+    export interface ws_accountPingResponse {
+
+    }
+
+    export interface UpdateUserRequest {
+        username?: string;
+        oldpass?: string;
+        newpass1?: string;
+        newpass2?: string;
+    }
+
+    export interface UpdateUserResponse {
+        Exceptions: Exceptions;
+        retcode: int;
+        message: string;
+    }
+
+    export interface UpdateUserInputRequest {
+
+    }
+
+    export interface UpdateUserInputResponse {
+        Exceptions: Exceptions;
+        username: string;
+    }
+
+    export interface VerifyUserRequest {
+        application?: string;
+        version?: string;
+    }
+
+    export interface VerifyUserResponse {
+        Exceptions: Exceptions;
+        retcode: int;
+    }
+
+}
+
+export class AccountServiceBase extends Service {
+
+    constructor(optsConnection: IOptions | IConnection) {
+        super(optsConnection, "ws_account", "1.06");
+    }
+
+    MyAccount(request: Partial<WsAccount.MyAccountRequest>): Promise<WsAccount.MyAccountResponse> {
+        return this._connection.send("MyAccount", request, "json", false, undefined, "MyAccountResponse");
+    }
+
+    Ping(request: Partial<WsAccount.ws_accountPingRequest>): Promise<WsAccount.ws_accountPingResponse> {
+        return this._connection.send("Ping", request, "json", false, undefined, "ws_accountPingResponse");
+    }
+
+    UpdateUser(request: Partial<WsAccount.UpdateUserRequest>): Promise<WsAccount.UpdateUserResponse> {
+        return this._connection.send("UpdateUser", request, "json", false, undefined, "UpdateUserResponse");
+    }
+
+    UpdateUserInput(request: Partial<WsAccount.UpdateUserInputRequest>): Promise<WsAccount.UpdateUserInputResponse> {
+        return this._connection.send("UpdateUserInput", request, "json", false, undefined, "UpdateUserInputResponse");
+    }
+
+    VerifyUser(request: Partial<WsAccount.VerifyUserRequest>): Promise<WsAccount.VerifyUserResponse> {
+        return this._connection.send("VerifyUser", request, "json", false, undefined, "VerifyUserResponse");
+    }
+
+}


### PR DESCRIPTION
bumps ws_account to latest (1.06) and changed service to use the generated ws_account.ts. I opened and saved the 1.05 generated file, so all those changes are just whitespace.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
