### PR TITLE
feat(comms): add support for the Grafana/Loki log engine

### DIFF
--- a/packages/comms/src/services/wsLogaccess.ts
+++ b/packages/comms/src/services/wsLogaccess.ts
@@ -82,7 +82,11 @@ export class LogaccessService extends LogaccessServiceBase {
         const convertLogLine = (line: any) => {
             const retVal: LogLine = {};
             for (const key in columnMap) {
-                retVal[key] = line?.fields[0][columnMap[key]] ?? "";
+                if (line?.fields) {
+                    retVal[key] = Object.assign({}, ...line.fields)[columnMap[key]] ?? "";
+                } else {
+                    retVal[key] = "";
+                }
             }
             return retVal;
         };
@@ -236,6 +240,7 @@ export class LogaccessService extends LogaccessServiceBase {
                 switch (logInfo.RemoteLogManagerType) {
                     case "azureloganalyticscurl":
                     case "elasticstack":
+                    case "grafanacurl":
                         lines = logLines.lines?.map(convertLogLine) ?? [];
                         break;
                     default:


### PR DESCRIPTION
recognizes the grafana engine manager type, also reduces arrays of log fields down into single objects:

the elastic & log analytics (LA) engines return rows formatted like: 
```
{
  lines: [{
    fields: [
      { timestamp: "...", container: "...", ...},
    ]
  }]
}
```

and the loki engine currently returns rows formatted like: (separate objects per field)
```
{
  lines: [{
    fields: [
      { tsNs: "..." },
      { pod: "..."},
      { log: "..." }
    ]
  }]
}
```

so just forcing the loki engine results to look like the elastic & LA

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
