### PR TITLE
feat: Export `opts` for all services

### DIFF
--- a/packages/comms/src/ecl/activity.ts
+++ b/packages/comms/src/ecl/activity.ts
@@ -41,9 +41,7 @@ export class Activity extends StateObject<UActivityState, IActivityState> implem
             _activity = new Activity(optsConnection);
         }
         if (state) {
-            _activity.set({
-                ...state
-            });
+            _activity.set(state);
         }
         return _activity;
     }

--- a/packages/comms/src/ecl/logicalFile.ts
+++ b/packages/comms/src/ecl/logicalFile.ts
@@ -91,10 +91,13 @@ export class LogicalFile extends StateObject<FileDetailEx, FileDetailEx> impleme
 
     get properties(): FileDetailEx { return this.get(); }
 
-    static attach(optsConnection: IOptions | IConnection | DFUService, Cluster: string, Name: string): LogicalFile {
+    static attach(optsConnection: IOptions | IConnection | DFUService, Cluster: string, Name: string, state?: FileDetailEx): LogicalFile {
         const retVal: LogicalFile = _store.get({ BaseUrl: optsConnection.baseUrl, Cluster, Name }, () => {
             return new LogicalFile(optsConnection, Cluster, Name);
         });
+        if (state) {
+            retVal.set(state);
+        }
         return retVal;
     }
 

--- a/packages/comms/src/ecl/query.ts
+++ b/packages/comms/src/ecl/query.ts
@@ -78,10 +78,13 @@ export class Query extends StateObject<QueryEx, QueryEx> implements QueryEx {
         } as QueryEx);
     }
 
-    static attach(optsConnection: IOptions | IConnection, querySet: string, queryId: string): Query {
+    static attach(optsConnection: IOptions | IConnection, querySet: string, queryId: string, state?: QueryEx): Query {
         const retVal: Query = _queries.get({ BaseUrl: optsConnection.baseUrl, QuerySet: querySet, QueryId: queryId } as QueryEx, () => {
             return new Query(optsConnection, querySet, queryId);
         });
+        if (state) {
+            retVal.set(state);
+        }
         return retVal;
     }
 

--- a/packages/comms/src/ecl/targetCluster.ts
+++ b/packages/comms/src/ecl/targetCluster.ts
@@ -43,9 +43,7 @@ export class TargetCluster extends StateObject<UTargetClusterState, ITargetClust
             return new TargetCluster(optsConnection, name);
         });
         if (state) {
-            retVal.set({
-                ...state
-            });
+            retVal.set(state);
         }
         return retVal;
     }

--- a/packages/comms/src/ecl/topology.ts
+++ b/packages/comms/src/ecl/topology.ts
@@ -30,10 +30,13 @@ export class Topology extends StateObject<TopologyStateEx, TopologyStateEx> impl
     get LogicalClusters(): WsTopology.TpLogicalCluster[] { return this.get("LogicalClusters"); }
     get Services(): WsTopology.ServiceList { return this.get("Services"); }
 
-    static attach(optsConnection: IOptions | IConnection | TopologyService) {
+    static attach(optsConnection: IOptions | IConnection | TopologyService, state?: TopologyStateEx): Topology {
         const retVal: Topology = _topology.get({ BaseUrl: optsConnection.baseUrl }, () => {
             return new Topology(optsConnection);
         });
+        if (state) {
+            retVal.set(state);
+        }
         return retVal;
     }
 

--- a/packages/comms/src/espConnection.ts
+++ b/packages/comms/src/espConnection.ts
@@ -161,4 +161,12 @@ export class Service {
     constructor(optsConnection: IOptions | IConnection, service: string, version: string) {
         this._connection = new ESPConnection(optsConnection, service, version);
     }
+
+    opts() {
+        return this._connection.opts();
+    }
+
+    connection(): ESPConnection {
+        return this._connection.clone();
+    }
 }

--- a/packages/comms/src/services/wsWorkunits.ts
+++ b/packages/comms/src/services/wsWorkunits.ts
@@ -1,7 +1,6 @@
 import { deepMixin, xml2json, XMLNode } from "@hpcc-js/util";
 import { WsWorkunits, WorkunitsServiceBase } from "./wsdl/WsWorkunits/v2/WsWorkunits";
 import { IConnection, IOptions } from "../connection";
-import { ESPConnection } from "../espConnection";
 
 /*
     Response structures generated via:
@@ -65,14 +64,6 @@ export class WorkunitsService extends WorkunitsServiceBase {
 
     constructor(optsConnection: IOptions | IConnection) {
         super(optsConnection);
-    }
-
-    opts() {
-        return this._connection.opts();
-    }
-
-    connection(): ESPConnection {
-        return this._connection.clone();
     }
 
     Ping(): Promise<WsWorkunits.WsWorkunitsPingResponse> {


### PR DESCRIPTION
Make `attach` calls more consistent by allowing the current state to be passed in.

fixes #4277
fixes #4278

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
