### PR TITLE
fix:  Revert text autosize changes

### DIFF
--- a/packages/react/src/text.tsx
+++ b/packages/react/src/text.tsx
@@ -183,14 +183,14 @@ export const LabelledRect: FunctionComponent<LabelledRect> = ({
 
     return <>
         <Rectangle
-            width={actualWidth}
-            height={actualHeight}
+            width={width}
+            height={height}
             fill={fill}
             stroke={stroke}
             strokeWidth={strokeWidth}
             cornerRadius={cornerRadius}
         />
-        <g transform={`translate(${-(actualWidth / 2) + padding} ${-(actualHeight / 2) + padding + fontSize * 0.15})`}>
+        <g transform={`translate(${-(width / 2) + padding} ${-(height / 2) + padding})`}>
             <TextLine
                 text={text}
                 fontFamily={fontFamily}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [x] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
