### PR TITLE
fix(comms): fix assigment to undefined in QueryGraph.walkDocument

### DIFF
--- a/packages/comms/src/ecl/queryGraph.ts
+++ b/packages/comms/src/ecl/queryGraph.ts
@@ -753,9 +753,13 @@ export class QueryGraph {
                             } else if (edge._sourceActivity || edge._targetActivity) {
                                 edge._isSpill = true;
                                 const source = edge.getSource();
-                                source._isSpill = true;
+                                if (source) {
+                                    source._isSpill = true;
+                                }
                                 const target = edge.getTarget();
-                                target._isSpill = true;
+                                if (target) {
+                                    target._isSpill = true;
+                                }
                             }
                             retVal.addEdge(edge);
                             break;


### PR DESCRIPTION
checks if edge.getSource() and edge.getTarget() are undefined when attempting to set _isSpill on those objects to true

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
