### PR TITLE
fix(comms): scopeProperty measure "skw" should be int

### DIFF
--- a/packages/comms/src/ecl/workunit.ts
+++ b/packages/comms/src/ecl/workunit.ts
@@ -717,8 +717,10 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
                         case "node":
                             props[scopeProperty.Name] = +scopeProperty.RawValue;
                             break;
-                        case "cpu":
                         case "skw":
+                            props[scopeProperty.Name] = +scopeProperty.RawValue;
+                            break;
+                        case "cpu":
                         case "ppm":
                         case "ip":
                         case "cy":


### PR DESCRIPTION
in Workunit.normalizeDetails(), the raw value of scope properties of measure "skw" should be integers rather than strings

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
