### PR TITLE
fix(eclwatch): display error message in WUResult table

### DIFF
--- a/packages/dgrid/src/Common.ts
+++ b/packages/dgrid/src/Common.ts
@@ -58,7 +58,7 @@ export class Common extends HTMLWidget {
             const retVal = [];
             for (const id in this._dgrid.selection) {
                 if (this._dgrid.selection[id]) {
-                const storeItem = this._store.get(+id);
+                    const storeItem = this._store.get(+id);
                     retVal.push(this.rowToObj(storeItem));
                 }
             }

--- a/packages/eclwatch/src/WUResult.ts
+++ b/packages/eclwatch/src/WUResult.ts
@@ -92,7 +92,12 @@ export class WUResult extends Common {
             const result = this.calcResult();
             if (result) {
                 result.fetchXMLSchema().then(schema => {
-                    this._localStore = new Store(result, schema, this.renderHtml(), this.filter());
+                    this._localStore = new Store(result, schema, this.renderHtml(), this.filter(), (msg) => {
+                        if (this._dgrid) {
+                            this._dgrid.noDataMessage = `<span class='dojoxGridNoData'>${msg}</span>`;
+                            this._dgrid.refresh();
+                        }
+                    });
                     this._dgrid?.set("columns", this._localStore.columns());
                     this._dgrid?.set("collection", this._localStore);
                 });


### PR DESCRIPTION
catch exception thrown in wuResult.fetchRows() and pass that message back to the dgrid table to display instead of the normal noDataMessage

HPCC-32576 (Viewing a file does not pass back errors to the user)

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
