### PR TITLE
feat(comms): allow WUResult to set BypassCachedResult in request

### DIFF
--- a/packages/eclwatch/src/WUResult.ts
+++ b/packages/eclwatch/src/WUResult.ts
@@ -23,6 +23,7 @@ export class WUResult extends Common {
             logicalFile: this.logicalFile(),
             userID: this.user(),
             password: this.password(),
+            bypassCache: this.bypassCache(),
             ...opts
         });
     }
@@ -46,6 +47,10 @@ export class WUResult extends Common {
                 this._result = Result.attachLogicalFile(opts, this.nodeGroup(), this.logicalFile());
             } else if (this.logicalFile()) {
                 this._result = Result.attachLogicalFile(opts, "", this.logicalFile());
+            }
+
+            if (this._result && this.bypassCache()) {
+                this._result.bypassCache(this.bypassCache());
             }
         }
         return this._result;
@@ -109,6 +114,8 @@ export interface WUResult {
     logicalFile(_: string): this;
     filter(): ResultFilter;
     filter(_: ResultFilter): this;
+    bypassCache(): boolean;
+    bypassCache(_: boolean): this;
 }
 
 WUResult.prototype.publish("baseUrl", "", "string", "URL to WsWorkunits");
@@ -120,3 +127,4 @@ WUResult.prototype.publish("sequence", undefined, "number", "Sequence Number");
 WUResult.prototype.publish("nodeGroup", "", "string", "NodeGroup");
 WUResult.prototype.publish("logicalFile", "", "string", "Logical File Name");
 WUResult.prototype.publish("filter", {}, "object", "Filter");
+WUResult.prototype.publish("bypassCache", false, "boolean", "Bypass cached results");


### PR DESCRIPTION
changes the WUResult widget in the eclwatch package & ecl/result helper in comms to allow setting the BypassCachedResult param in requests to WorkunitsService.WUResult

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
