### PR TITLE
fix(timeline): fix tickFormat being ignored

### DIFF
--- a/packages/chart/src/Axis.ts
+++ b/packages/chart/src/Axis.ts
@@ -676,6 +676,7 @@ export interface Axis {
     tickFormat(): string;
     tickFormat(_: string): this;
     tickFormat_exists(): boolean;
+    tickFormat_reset(): void;
     tickLength(): number;
     tickLength(_: number): this;
     tickLength_exists(): boolean;

--- a/packages/timeline/src/ReactTimeline.ts
+++ b/packages/timeline/src/ReactTimeline.ts
@@ -42,11 +42,15 @@ export class ReactTimeline extends ReactAxisGantt {
                     highDateStr = "" + n[2];
                 }
             });
+
+            const axisTickFormat = this._axisLabelFormatter
+                ? this._axisLabelFormatter
+                : (this.tickFormat_exists && this.tickFormat_exists() ? this.tickFormat() : undefined);
+
             this._topAxis
                 .type("time")
                 .timePattern(this.timePattern())
                 .overlapMode("none")
-                .tickFormat(this._axisLabelFormatter)
                 .low(lowDateStr)
                 .high(highDateStr)
                 ;
@@ -54,10 +58,17 @@ export class ReactTimeline extends ReactAxisGantt {
                 .type("time")
                 .timePattern(this.timePattern())
                 .overlapMode("none")
-                .tickFormat(this._axisLabelFormatter)
                 .low(lowDateStr)
                 .high(highDateStr)
                 ;
+
+            if (axisTickFormat) {
+                this._topAxis.tickFormat(axisTickFormat);
+                this._bottomAxis.tickFormat(axisTickFormat);
+            } else {
+                this._topAxis.tickFormat_reset();
+                this._bottomAxis.tickFormat_reset();
+            }
             this._gantt._minStart = minTimestamp;
             this._gantt._maxEnd = maxTimestamp;
         }

--- a/packages/timeline/src/ReactTimelineSeries.ts
+++ b/packages/timeline/src/ReactTimelineSeries.ts
@@ -41,11 +41,15 @@ export class ReactTimelineSeries extends ReactAxisGanttSeries {
                     highDateStr = "" + n[2];
                 }
             });
+
+            const axisTickFormat = this._axisLabelFormatter
+                ? this._axisLabelFormatter
+                : (this.tickFormat_exists && this.tickFormat_exists() ? this.tickFormat() : undefined);
+
             this._topAxis
                 .type("time")
                 .timePattern(this.timePattern())
                 .overlapMode("none")
-                .tickFormat(this._axisLabelFormatter)
                 .low(lowDateStr)
                 .high(highDateStr)
                 ;
@@ -53,10 +57,17 @@ export class ReactTimelineSeries extends ReactAxisGanttSeries {
                 .type("time")
                 .timePattern(this.timePattern())
                 .overlapMode("none")
-                .tickFormat(this._axisLabelFormatter)
                 .low(lowDateStr)
                 .high(highDateStr)
                 ;
+
+            if (axisTickFormat) {
+                this._topAxis.tickFormat(axisTickFormat);
+                this._bottomAxis.tickFormat(axisTickFormat);
+            } else {
+                this._topAxis.tickFormat_reset();
+                this._bottomAxis.tickFormat_reset();
+            }
             this._gantt._minStart = minTimestamp;
             this._gantt._maxEnd = maxTimestamp;
         }


### PR DESCRIPTION
Fixes an issue where tickFormat called by consumers of this component was being ignored / overwritten by _axisLabelFormatter. This resulted in d3-time-format defaulting back to it's 12-hour "AM/PM" notation

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
