### PR TITLE
fix(comms): adds back some interfaces to wsDFUXRef

### DIFF
--- a/packages/comms/src/services/wsDFUXRef.ts
+++ b/packages/comms/src/services/wsDFUXRef.ts
@@ -1,7 +1,121 @@
 import { DFUXRefServiceBase, type WsDFUXRef } from "./wsdl/WsDFUXRef/v1.04/WsDFUXRef.ts";
 
-export { type WsDFUXRef };
+export {
+    type WsDFUXRef
+};
+
+export namespace WsDFUXRefEx {
+
+    export interface Request {
+        DFUXRefArrayActionRequest: WsDFUXRef.DFUXRefArrayActionRequest;
+        DFUXRefBuildRequest: WsDFUXRef.DFUXRefBuildRequest;
+        DFUXRefBuildCancelRequest: WsDFUXRef.DFUXRefBuildCancelRequest;
+        DFUXRefCleanDirectoriesRequest: WsDFUXRef.DFUXRefCleanDirectoriesRequest;
+        DFUXRefDirectoriesQueryRequest: WsDFUXRef.DFUXRefDirectoriesQueryRequest;
+        DFUXRefFoundFilesQueryRequest: WsDFUXRef.DFUXRefFoundFilesQueryRequest;
+        DFUXRefListRequest: WsDFUXRef.DFUXRefListRequest;
+        DFUXRefLostFilesQueryRequest: WsDFUXRef.DFUXRefLostFilesQueryRequest;
+        DFUXRefMessagesQueryRequest: WsDFUXRef.DFUXRefMessagesQueryRequest;
+        DFUXRefOrphanFilesQueryRequest: WsDFUXRef.DFUXRefOrphanFilesQueryRequest;
+        DFUXRefUnusedFilesRequest: WsDFUXRef.DFUXRefUnusedFilesRequest;
+        WsDFUXRefPingRequest: WsDFUXRef.WsDFUXRefPingRequest;
+    }
+
+    export interface Directory {
+        Num: string;
+        Name: string;
+        MaxSize: string;
+        MaxIP: string;
+        MinSize: string;
+        MinIP: string;
+        Size: string;
+        PositiveSkew: string;
+    }
+
+    interface DFUXRefDirectoriesQueryResult {
+        Directory: Directory[];
+        Cluster: string;
+    }
+
+    export interface DFUXRefDirectoriesQueryResponseEx {
+        DFUXRefDirectoriesQueryResult: DFUXRefDirectoriesQueryResult;
+    }
+
+    export interface Part {
+        Num: string;
+        Node: string;
+    }
+
+    export interface DFUXRefFile {
+        Size: string;
+        Partmask: string;
+        Modified: Date;
+        Numparts: string;
+        Part: Part[];
+    }
+
+    export interface DFUXRefFoundFilesQueryResult {
+        File: DFUXRefFile[];
+        Cluster: string;
+    }
+
+    export interface XRefNode {
+        Name: string;
+        Modified: string;
+        Status: string;
+    }
+
+    export interface DFUXRefListResult {
+        XRefNode: XRefNode[];
+    }
+
+    export interface DFUXRefListResponseEx {
+        DFUXRefListResult: DFUXRefListResult;
+    }
+
+    export interface File2 {
+        Partslost: string;
+        Name: string;
+        Partmask: string;
+        Modified: Date;
+        Numparts: string;
+        Part: Part[];
+        Cluster: string;
+        Size: string;
+        Primarylost: string;
+        Replicatedlost: string;
+    }
+
+    export interface DFUXRefLostFilesQueryResult {
+        File: File2[];
+        Cluster: string;
+    }
+
+    export interface Warning {
+        Text: string;
+        File: string;
+    }
+
+    export interface DFUXRefMessagesQueryResult {
+        Warning: Warning[];
+        Cluster: string;
+    }
+
+    export interface DFUXRefOrphanFilesQueryResult {
+        File: DFUXRefFile[];
+        Cluster: string;
+    }
+
+}
 
 export class DFUXRefService extends DFUXRefServiceBase {
+
+    DFUXRefDirectoriesEx(request: Partial<WsDFUXRef.DFUXRefDirectoriesQueryRequest>): Promise<WsDFUXRefEx.DFUXRefDirectoriesQueryResponseEx> {
+        return this._connection.send("DFUXRefDirectories", request, "json", false, undefined, "DFUXRefDirectoriesQueryResponse");
+    }
+
+    DFUXRefListEx(request: Partial<WsDFUXRef.DFUXRefListRequest>): Promise<WsDFUXRefEx.DFUXRefListResponseEx> {
+        return this._connection.send("DFUXRefList", request, "json", false, undefined, "DFUXRefListResponse");
+    }
 
 }

--- a/packages/comms/tests/dfuXRef.spec.ts
+++ b/packages/comms/tests/dfuXRef.spec.ts
@@ -9,7 +9,7 @@ describe("DFUXRefService", () => {
     it.skip("directories", async () => {
         const dfuXRefService = new DFUXRefService(new Connection({ baseUrl: "https://play.hpccsystems.com:18010/", rejectUnauthorized: false }));
         expect(dfuXRefService).to.exist;
-        const xrefNodes = await dfuXRefService.DFUXRefList().then(response => {
+        const xrefNodes = await dfuXRefService.DFUXRefListEx({}).then(response => {
             expect(response.DFUXRefListResult).to.exist;
             expect(response.DFUXRefListResult.XRefNode).to.have.length;
             return response.DFUXRefListResult.XRefNode;


### PR DESCRIPTION
there are apparently several interfaces that were previously defined manually in the wsDFUXRef service file, but are missing from the WSDL. this adds back any such interfaces & extends two functions where the WSDL defines the return type as a string instead of an object.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
