### PR TITLE
feat(timeline): add zoom preservation to timeline series

### DIFF
--- a/packages/timeline/src/ReactAxisGanttSeries.ts
+++ b/packages/timeline/src/ReactAxisGanttSeries.ts
@@ -237,6 +237,8 @@ export interface ReactAxisGanttSeries {
     bucketColumn(_: string): this;
     maxZoom(): number;
     maxZoom(_: number): this;
+    preserveZoom(): boolean;
+    preserveZoom(_: boolean): this;
 }
 ReactAxisGanttSeries.prototype.publish("tickFormat", null, "string", "Format rule applied to axis tick labels", undefined, { optional: true });
 ReactAxisGanttSeries.prototype.publish("axisHeight", 22, "number", "Height of axes (pixels)");
@@ -260,6 +262,7 @@ ReactAxisGanttSeries.prototype.publishProxy("colorColumn", "_gantt");
 ReactAxisGanttSeries.prototype.publishProxy("seriesColumn", "_gantt");
 ReactAxisGanttSeries.prototype.publishProxy("bucketColumn", "_gantt");
 ReactAxisGanttSeries.prototype.publishProxy("maxZoom", "_gantt");
+ReactAxisGanttSeries.prototype.publishProxy("preserveZoom", "_gantt");
 ReactAxisGanttSeries.prototype.publishProxy("evenSeriesBackground", "_gantt");
 ReactAxisGanttSeries.prototype.publishProxy("oddSeriesBackground", "_gantt");
 ReactAxisGanttSeries.prototype.publishProxy("bucketHeight", "_gantt");


### PR DESCRIPTION
exposes a boolean property that when set allows the gantt chart to maintain its current zoom level instead of zooming to fit all items on update

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
