### PR TITLE
feat(comms): adds StateReason to FileSpray

### DIFF
--- a/packages/comms/src/ecl/dfuWorkunit.ts
+++ b/packages/comms/src/ecl/dfuWorkunit.ts
@@ -80,6 +80,7 @@ export class DFUWorkunit extends StateObject<UDFUWorkunitState, IDFUWorkunitStat
     get TimeStarted(): string { return this.get("TimeStarted"); }
     get TimeStopped(): string { return this.get("TimeStopped"); }
     get StateMessage(): string { return this.get("StateMessage"); }
+    get StateReason(): string { return this.get("StateReason"); }
     get MonitorEventName(): string { return this.get("MonitorEventName"); }
     get MonitorSub(): boolean { return this.get("MonitorSub"); }
     get MonitorShotLimit(): number { return this.get("MonitorShotLimit"); }

--- a/packages/comms/src/services/wsdl/FileSpray/v1.29/FileSpray.ts
+++ b/packages/comms/src/services/wsdl/FileSpray/v1.29/FileSpray.ts
@@ -139,6 +139,7 @@ export namespace FileSpray {
         TimeStarted?: string;
         TimeStopped?: string;
         StateMessage?: string;
+        StateReason?: string;
         MonitorEventName?: string;
         MonitorSub?: boolean;
         MonitorShotLimit?: int;
@@ -501,6 +502,7 @@ export namespace FileSpray {
         TimeStarted?: string;
         TimeStopped?: string;
         StateMessage?: string;
+        StateReason?: string;
         MonitorEventName?: string;
         MonitorSub?: boolean;
         MonitorShotLimit?: int;
@@ -776,6 +778,7 @@ export namespace FileSpray {
         TimeStarted?: string;
         TimeStopped?: string;
         StateMessage?: string;
+        StateReason?: string;
         MonitorEventName?: string;
         MonitorSub?: boolean;
         MonitorShotLimit?: int;


### PR DESCRIPTION
StateReason is a string field added in ESP to show a reason for a WU's State, eg why is something blocked

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
