### PR TITLE
fix(comms): add "recover" function in ecl/workunit

### DIFF
--- a/packages/comms/src/ecl/workunit.ts
+++ b/packages/comms/src/ecl/workunit.ts
@@ -548,10 +548,23 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
         return this.WUAction(WsWorkunits.ECLWUActions.Reschedule);
     }
 
-    resubmit(): Promise<Workunit> {
+    recover(): Promise<Workunit> {
         return this.WUResubmit({
             CloneWorkunit: false,
             ResetWorkflow: false
+        }).then(() => {
+            this.clearState(this.Wuid);
+            return this.refresh().then(() => {
+                this._monitor();
+                return this;
+            });
+        });
+    }
+
+    resubmit(): Promise<Workunit> {
+        return this.WUResubmit({
+            CloneWorkunit: false,
+            ResetWorkflow: true
         }).then(() => {
             this.clearState(this.Wuid);
             return this.refresh().then(() => {


### PR DESCRIPTION
* expose a "recover" convenience function in ecl/workunit
* fix the flags passed to WUResubmit by the "resubmit" function

Those flags being passed to WUResubmit appear to have always been wrong? When comparing the oldest history of ecl/workunit.ts (https://github.com/hpcc-systems/Visualization/blob/380a07396b853ed4324b3e8de000da7769cc36a7/packages/comms/src/ecl/workunit.ts#L384-L387) with the oldest history of src/ESPWorkunit.ts in the HPCC-Platform (https://github.com/hpcc-systems/HPCC-Platform/blob/40d2bf091dbfdc588ce7d5378bddce4d787b525b/esp/src/src/ESPWorkunit.ts#L384)

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
