### PR TITLE
fix(phosphor): set min-height to 48px

### DIFF
--- a/packages/phosphor/src/WidgetAdapter.css
+++ b/packages/phosphor/src/WidgetAdapter.css
@@ -4,7 +4,7 @@
   border-bottom: 1px solid #C0C0C0;
   background: white;
   min-width: 64px;
-  min-height: 64px;
+  min-height: 48px;
 }
 
 .phosphor_WidgetAdapter.lm-DockPanel-widget {


### PR DESCRIPTION
would allow eclwatch to "minimize" the WU errors/warnings infogrid

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
