### PR TITLE
fix(dgrid-shim): use cross-env for the bundle script

### DIFF
--- a/packages/dgrid-shim/package.json
+++ b/packages/dgrid-shim/package.json
@@ -17,7 +17,7 @@
         "clean": "rimraf --glob lib* types types-3.4 dist *.tsbuildinfo",
         "compile": "tsc",
         "compile-watch": "npm run compile -- -w",
-        "bundle": "NODE_OPTIONS='-r ts-node/register/transpile-only' webpack --config webpack.config.ts",
+        "bundle": "cross-env NODE_OPTIONS=\"-r ts-node/register/transpile-only\" webpack --config webpack.config.ts",
         "bundle-watch": "npm run bundle -- -w",
         "minimize": "terser dist/index.js -c -m -o dist/index.min.js",
         "gen-legacy-types": "downlevel-dts ./types ./types-3.4",


### PR DESCRIPTION
fixes an issue with the npm bundle script not working on windows

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [x] The commit is signed.
- [ ] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
