### PR TITLE
feat(comms): Add opt-in arraybuffer response type to fetchDetails

### DIFF
--- a/packages/comms/src/connection.ts
+++ b/packages/comms/src/connection.ts
@@ -163,7 +163,7 @@ function doFetch(opts: IOptions, action: string, requestInit: RequestInit, heade
         }
     }
 
-    function handleResponse(response: Response): Promise<any> {
+    function handleResponse(response: Response): Promise<any | ArrayBuffer | string> {
         if (response.ok) {
             switch (responseType) {
                 case "json":

--- a/packages/comms/src/connection.ts
+++ b/packages/comms/src/connection.ts
@@ -3,7 +3,7 @@ import { join, promiseTimeout, root, scopedLogger, utf8ToBase64 } from "@hpcc-js
 const logger = scopedLogger("comms/connection.ts");
 
 export type RequestType = "post" | "get" | "jsonp";
-export type ResponseType = "json" | "text";
+export type ResponseType = "json" | "text" | "arraybuffer";
 
 export type IOptionsSend = (options: IOptions, action: string, request: any, responseType: ResponseType, defaultSend: SendFunc, header?: any) => Promise<any>;
 export interface IOptions {
@@ -165,7 +165,15 @@ function doFetch(opts: IOptions, action: string, requestInit: RequestInit, heade
 
     function handleResponse(response: Response): Promise<any> {
         if (response.ok) {
-            return responseType === "json" ? response.json() : response.text();
+            switch (responseType) {
+                case "json":
+                    return response.json();
+                case "arraybuffer":
+                    return response.arrayBuffer();
+                case "text":
+                default:
+                    return response.text();
+            }
         }
         throw new Error(response.statusText);
     }

--- a/packages/comms/src/ecl/workunit.ts
+++ b/packages/comms/src/ecl/workunit.ts
@@ -195,6 +195,14 @@ export interface ITimeElapsed {
     finish: string;
 }
 
+export interface IFetchDetailsOptions {
+    bypassResponseParsing?: boolean;
+}
+
+export interface IFetchDetailsRawResponseOptions extends IFetchDetailsOptions {
+    bypassResponseParsing: true;
+}
+
 export type WorkunitEvents = "completed" | StateEvents;
 export type UWorkunitState = WsWorkunits.ECLWorkunit & WsWorkunits.Workunit & WsSMC.ActiveWorkunit & IWorkunit & IDebugWorkunit;
 export type IWorkunitState = WsWorkunits.ECLWorkunit | WsWorkunits.Workunit | WsSMC.ActiveWorkunit | IWorkunit | IDebugWorkunit;
@@ -676,7 +684,12 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
         return this.WUDetailsMeta(request);
     }
 
-    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails> = {}): Promise<WsWorkunits.Scope[]> {
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails> | undefined, options: IFetchDetailsRawResponseOptions): Promise<ArrayBuffer>;
+    fetchDetailsRaw(request?: RecursivePartial<WsWorkunits.WUDetails>, options?: IFetchDetailsOptions): Promise<WsWorkunits.Scope[]>;
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails> = {}, options: IFetchDetailsOptions = {}): Promise<WsWorkunits.Scope[] | ArrayBuffer> {
+        if (options.bypassResponseParsing === true) {
+            return this.WUDetailsRawPayload(request);
+        }
         return this.WUDetails(request).then(response => response.Scopes.Scope);
     }
 
@@ -833,7 +846,12 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
         return this.WUInfo(request);
     }
 
-    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails> = {}): Promise<Scope[]> {
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails> | undefined, options: IFetchDetailsRawResponseOptions): Promise<ArrayBuffer>;
+    fetchDetails(request?: RecursivePartial<WsWorkunits.WUDetails>, options?: IFetchDetailsOptions): Promise<Scope[]>;
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails> = {}, options: IFetchDetailsOptions = {}): Promise<Scope[] | ArrayBuffer> {
+        if (options.bypassResponseParsing === true) {
+            return this.WUDetailsRawPayload(request);
+        }
         return this.WUDetails(request).then((response) => {
             return response.Scopes.Scope.map((rawScope) => {
                 return new Scope(this, rawScope);
@@ -1143,6 +1161,28 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
                 }
             }, response);
         });
+    }
+
+    protected WUDetailsRawPayload(request: RecursivePartial<WsWorkunits.WUDetails>): Promise<ArrayBuffer> {
+        return this.connection.WUDetailsRawPayload(deepMixinT<WsWorkunits.WUDetails>({
+            ScopeFilter: {
+                MaxDepth: 9999
+            },
+            ScopeOptions: {
+                IncludeMatchedScopesInResults: true,
+                IncludeScope: true,
+                IncludeId: false,
+                IncludeScopeType: false
+            },
+            PropertyOptions: {
+                IncludeName: true,
+                IncludeRawValue: false,
+                IncludeFormatted: true,
+                IncludeMeasure: true,
+                IncludeCreator: false,
+                IncludeCreatorType: false
+            }
+        }, request, { WUID: this.Wuid }));
     }
 
     protected WUAction(actionType: WsWorkunits.ECLWUActions): Promise<WsWorkunits.WUActionResponse> {

--- a/packages/comms/src/ecl/workunit.ts
+++ b/packages/comms/src/ecl/workunit.ts
@@ -2,7 +2,7 @@ import { Cache, deepMixinT, IEvent, RecursivePartial, scopedLogger, StateCallbac
 import { format as d3Format } from "d3-format";
 import { utcFormat, utcParse } from "d3-time-format";
 import { IConnection, IOptions } from "../connection.ts";
-import { ESPExceptions } from "../espConnection.ts";
+import { ESPExceptions, ESPResponseType } from "../espConnection.ts";
 import { WsSMC } from "../services/wsSMC.ts";
 import * as WsTopology from "../services/wsTopology.ts";
 import { WsWorkunits, WUStateID, WorkunitsService, WorkunitsServiceEx, WUUpdate } from "../services/wsWorkunits.ts";
@@ -193,14 +193,6 @@ export interface ITimeElapsed {
     start: string;
     elapsed: number;
     finish: string;
-}
-
-export interface IFetchDetailsOptions {
-    bypassResponseParsing?: boolean;
-}
-
-export interface IFetchDetailsRawResponseOptions extends IFetchDetailsOptions {
-    bypassResponseParsing: true;
 }
 
 export type WorkunitEvents = "completed" | StateEvents;
@@ -684,13 +676,24 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
         return this.WUDetailsMeta(request);
     }
 
-    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails> | undefined, options: IFetchDetailsRawResponseOptions): Promise<ArrayBuffer>;
-    fetchDetailsRaw(request?: RecursivePartial<WsWorkunits.WUDetails>, options?: IFetchDetailsOptions): Promise<WsWorkunits.Scope[]>;
-    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails> = {}, options: IFetchDetailsOptions = {}): Promise<WsWorkunits.Scope[] | ArrayBuffer> {
-        if (options.bypassResponseParsing === true) {
-            return this.WUDetailsRawPayload(request);
-        }
-        return this.WUDetails(request).then(response => response.Scopes.Scope);
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<WsWorkunits.Scope[]>;
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "json"): Promise<WsWorkunits.Scope[]>;
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "arraybuffer"): Promise<ArrayBuffer>;
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "text"): Promise<string>;
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "xsd"): Promise<string>;
+    fetchDetailsRaw(request: RecursivePartial<WsWorkunits.WUDetails> = {}, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<WsWorkunits.Scope[] | ArrayBuffer | string> {
+        return this.WUDetails(request, abortSignal, espResponseType).then(response => {
+            switch (espResponseType) {
+                case "arraybuffer":
+                    return response as ArrayBuffer;
+                case "text":
+                case "xsd":
+                    return response as string;
+                case "json":
+                default:
+                    return response.Scopes.Scope;
+            }
+        });
     }
 
     normalizeDetails(meta: WsWorkunits.WUDetailsMetaResponse, scopes: WsWorkunits.Scope[]): { meta: WsWorkunits.WUDetailsMetaResponse, columns: { [id: string]: any }, data: IScope[] } {
@@ -846,16 +849,25 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
         return this.WUInfo(request);
     }
 
-    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails> | undefined, options: IFetchDetailsRawResponseOptions): Promise<ArrayBuffer>;
-    fetchDetails(request?: RecursivePartial<WsWorkunits.WUDetails>, options?: IFetchDetailsOptions): Promise<Scope[]>;
-    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails> = {}, options: IFetchDetailsOptions = {}): Promise<Scope[] | ArrayBuffer> {
-        if (options.bypassResponseParsing === true) {
-            return this.WUDetailsRawPayload(request);
-        }
-        return this.WUDetails(request).then((response) => {
-            return response.Scopes.Scope.map((rawScope) => {
-                return new Scope(this, rawScope);
-            });
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<Scope[]>;
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "json"): Promise<Scope[]>;
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "arraybuffer"): Promise<ArrayBuffer>;
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "text"): Promise<string>;
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "xsd"): Promise<string>;
+    fetchDetails(request: RecursivePartial<WsWorkunits.WUDetails> = {}, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<Scope[] | ArrayBuffer | string> {
+        return this.WUDetails(request, abortSignal, espResponseType).then((response) => {
+            switch (espResponseType) {
+                case "arraybuffer":
+                    return response as ArrayBuffer;
+                case "text":
+                case "xsd":
+                    return response as string;
+                case "json":
+                default:
+                    return response.Scopes.Scope.map((rawScope) => {
+                        return new Scope(this, rawScope);
+                    });
+            }
         });
     }
 
@@ -1135,8 +1147,13 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
         return this.connection.WUDetailsMeta(request);
     }
 
-    protected WUDetails(request: RecursivePartial<WsWorkunits.WUDetails>): Promise<WsWorkunits.WUDetailsResponse> {
-        return this.connection.WUDetails(deepMixinT<WsWorkunits.WUDetails>({
+    protected WUDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<WsWorkunits.WUDetailsResponse>;
+    protected WUDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "json"): Promise<WsWorkunits.WUDetailsResponse>;
+    protected WUDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "arraybuffer"): Promise<ArrayBuffer>;
+    protected WUDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "text"): Promise<string>;
+    protected WUDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal: AbortSignal | undefined, espResponseType: "xsd"): Promise<string>;
+    protected WUDetails(request: RecursivePartial<WsWorkunits.WUDetails>, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<WsWorkunits.WUDetailsResponse | ArrayBuffer | string> {
+        return this.connection.WUDetailsEx(deepMixinT<WsWorkunits.WUDetails>({
             ScopeFilter: {
                 MaxDepth: 9999
             },
@@ -1154,35 +1171,24 @@ export class Workunit extends StateObject<UWorkunitState, IWorkunitState> implem
                 IncludeCreator: false,
                 IncludeCreatorType: false
             }
-        }, request, { WUID: this.Wuid })).then((response) => {
-            return deepMixinT<WsWorkunits.WUDetailsResponse>({
-                Scopes: {
-                    Scope: []
-                }
-            }, response);
+        }, request, { WUID: this.Wuid }), abortSignal, espResponseType).then((response) => {
+            switch (espResponseType) {
+                case "arraybuffer":
+                case "text":
+                case "xsd":
+                    return response;
+                case "json":
+                default:
+                    if (response.Scopes === undefined) {
+                        response.Scopes = {
+                            Scope: []
+                        };
+                    } else if (response.Scopes.Scope === undefined) {
+                        response.Scopes.Scope = [];
+                    }
+                    return response;
+            }
         });
-    }
-
-    protected WUDetailsRawPayload(request: RecursivePartial<WsWorkunits.WUDetails>): Promise<ArrayBuffer> {
-        return this.connection.WUDetailsRawPayload(deepMixinT<WsWorkunits.WUDetails>({
-            ScopeFilter: {
-                MaxDepth: 9999
-            },
-            ScopeOptions: {
-                IncludeMatchedScopesInResults: true,
-                IncludeScope: true,
-                IncludeId: false,
-                IncludeScopeType: false
-            },
-            PropertyOptions: {
-                IncludeName: true,
-                IncludeRawValue: false,
-                IncludeFormatted: true,
-                IncludeMeasure: true,
-                IncludeCreator: false,
-                IncludeCreatorType: false
-            }
-        }, request, { WUID: this.Wuid }));
     }
 
     protected WUAction(actionType: WsWorkunits.ECLWUActions): Promise<WsWorkunits.WUActionResponse> {

--- a/packages/comms/src/espConnection.ts
+++ b/packages/comms/src/espConnection.ts
@@ -108,6 +108,10 @@ export class ESPConnection implements IConnection {
                 serviceAction = join(this._service, action);
                 responseType = "text";
                 break;
+            case "arraybuffer":
+                serviceAction = join(this._service, action + ".json");
+                responseType = "arraybuffer";
+                break;
             case "xsd":
                 serviceAction = join(this._service, action + ".xsd");
                 responseType = "text";

--- a/packages/comms/src/espConnection.ts
+++ b/packages/comms/src/espConnection.ts
@@ -122,6 +122,7 @@ export class ESPConnection implements IConnection {
                 const actionParts = action.split("/");
                 action = actionParts.pop()!;
                 break;
+            case "json":
             default:
                 serviceAction = join(this._service, action + ".json");
         }

--- a/packages/comms/src/services/wsWorkunits.ts
+++ b/packages/comms/src/services/wsWorkunits.ts
@@ -1,6 +1,7 @@
 import { deepMixin, xml2json, XMLNode } from "@hpcc-js/util";
 import { WsWorkunits, WorkunitsServiceBase } from "./wsdl/WsWorkunits/v2.10/WsWorkunits.ts";
 import { IConnection, IOptions } from "../connection.ts";
+import { type ESPResponseType } from "../espConnection.ts";
 
 export {
     WsWorkunits
@@ -132,8 +133,13 @@ export class WorkunitsService extends WorkunitsServiceBase {
         return this._WUDetailsMetaPromise;
     }
 
-    WUDetailsRawPayload(request: WsWorkunits.WUDetails): Promise<ArrayBuffer> {
-        return this._connection.send("WUDetails", request, "arraybuffer", false);
+    WUDetailsEx(request: WsWorkunits.WUDetails, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<WsWorkunits.WUDetailsResponse>;
+    WUDetailsEx(request: WsWorkunits.WUDetails, abortSignal: AbortSignal | undefined, espResponseType: "json"): Promise<WsWorkunits.WUDetailsResponse>;
+    WUDetailsEx(request: WsWorkunits.WUDetails, abortSignal: AbortSignal | undefined, espResponseType: "arraybuffer"): Promise<ArrayBuffer>;
+    WUDetailsEx(request: WsWorkunits.WUDetails, abortSignal: AbortSignal | undefined, espResponseType: "text"): Promise<string>;
+    WUDetailsEx(request: WsWorkunits.WUDetails, abortSignal: AbortSignal | undefined, espResponseType: "xsd"): Promise<string>;
+    WUDetailsEx(request: WsWorkunits.WUDetails, abortSignal?: AbortSignal, espResponseType?: ESPResponseType): Promise<WsWorkunits.WUDetailsResponse | ArrayBuffer | string> {
+        return this._connection.send("WUDetails", request, espResponseType, false, abortSignal, "WUDetailsResponse");
     }
 
     WUCDebugEx(request: WsWorkunits.WUCDebug): Promise<XMLNode | null> {

--- a/packages/comms/src/services/wsWorkunits.ts
+++ b/packages/comms/src/services/wsWorkunits.ts
@@ -132,6 +132,10 @@ export class WorkunitsService extends WorkunitsServiceBase {
         return this._WUDetailsMetaPromise;
     }
 
+    WUDetailsRawPayload(request: WsWorkunits.WUDetails): Promise<ArrayBuffer> {
+        return this._connection.send("WUDetails", request, "arraybuffer", false);
+    }
+
     WUCDebugEx(request: WsWorkunits.WUCDebug): Promise<XMLNode | null> {
         return this._connection.send("WUCDebug", request, undefined, undefined, undefined, "WUDebug").then((response) => {
             const retVal = xml2json(response.Result);

--- a/packages/comms/tests/workunit.spec.ts
+++ b/packages/comms/tests/workunit.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { Workunit } from "@hpcc-js/comms";
+import { Workunit, WsWorkunits } from "@hpcc-js/comms";
 import { scopedLogger } from "@hpcc-js/util";
 import { ESP_URL } from "./testLib.ts";
 
@@ -135,43 +135,61 @@ OUTPUT(topUrls);
                 });
             });
         });
-        it("WUDetails array response", async () => {
-            await wu1.watchUntilComplete();
+        const WUDetailsRequest = {
+            "ScopeFilter": {
+                "MaxDepth": 1,
+                "ScopeTypes": ["all"]
+            },
+            "NestedFilter": {
+                "Depth": 999999,
+                "ScopeTypes": []
+            },
+            "PropertiesToReturn": {
+                "AllScopes": true,
+                "AllAttributes": true,
+                "AllProperties": true,
+                "AllNotes": true,
+                "AllStatistics": true,
+                "AllHints": true
+            },
+            "ScopeOptions": {
+                "IncludeId": true,
+                "IncludeScope": true,
+                "IncludeScopeType": true,
+                "IncludeMatchedScopesInResults": true
+            },
+            "PropertyOptions": {
+                "IncludeName": true,
+                "IncludeRawValue": true,
+                "IncludeFormatted": true,
+                "IncludeMeasure": true,
+                "IncludeCreator": false,
+                "IncludeCreatorType": false
+            }
+        };
+        it("WUDetails response", async () => {
             expect(wu1.isComplete(), "isComplete").is.true;
-            return wu1.fetchDetailsRaw({
-                "ScopeFilter": {
-                    "MaxDepth": 1,
-                    "ScopeTypes": ["all"]
-                },
-                "NestedFilter": {
-                    "Depth": 999999,
-                    "ScopeTypes": []
-                },
-                "PropertiesToReturn": {
-                    "AllScopes": true,
-                    "AllAttributes": true,
-                    "AllProperties": true,
-                    "AllNotes": true,
-                    "AllStatistics": true,
-                    "AllHints": true
-                },
-                "ScopeOptions": {
-                    "IncludeId": true,
-                    "IncludeScope": true,
-                    "IncludeScopeType": true,
-                    "IncludeMatchedScopesInResults": true
-                },
-                "PropertyOptions": {
-                    "IncludeName": true,
-                    "IncludeRawValue": true,
-                    "IncludeFormatted": true,
-                    "IncludeMeasure": true,
-                    "IncludeCreator": false,
-                    "IncludeCreatorType": false
-                }
-            }).then((response) => {
+            return wu1.fetchDetailsRaw(WUDetailsRequest).then((response) => {
                 expect(response).to.be.an("array");
                 expect(response.length).to.be.greaterThan(0);
+            });
+        });
+        it("WUDetails text response", async () => {
+            expect(wu1.isComplete(), "isComplete").is.true;
+            return wu1.fetchDetailsRaw(WUDetailsRequest, undefined, "text").then((response) => {
+                expect(response).to.be.a("string");
+                expect(response.length).to.be.greaterThan(0);
+            });
+        });
+        it("WUDetails arraybuffer response", async () => {
+            expect(wu1.isComplete(), "isComplete").is.true;
+            const jsonResponse = await wu1.fetchDetailsRaw(WUDetailsRequest);
+            return wu1.fetchDetailsRaw(WUDetailsRequest, undefined, "arraybuffer").then((response) => {
+                expect(response).to.be.a("ArrayBuffer");
+                expect(response.byteLength).to.be.greaterThan(0);
+                const jsonData: { WUDetailsResponse: WsWorkunits.WUDetailsResponse } = JSON.parse(new TextDecoder().decode(response));
+                expect(jsonData).to.be.an("object");
+                expect(jsonData.WUDetailsResponse.Scopes.Scope).to.deep.equal(jsonResponse);
             });
         });
         it("clone", async () => {


### PR DESCRIPTION
Added the `options` argument to `fetchDetails()` signatures and the response type of `arraybuffer` to allow callers of fetchDetails/fetchDetailsRaw to handle their own parsing. 


## Checklist:
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit message includes a "fixes" reference if appropriate.
  - [ ] The commit is signed.
- [x] The change has been fully tested:
  - [ ] I have viewed all related gallery items
  - [ ] I have viewed all related dermatology items
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised new issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->
- Unit tests failure rate was the same before and after the changes. I believe the failures were due to not having an esp running locally
- Built the package locally with `npm pack` and used it in the following snippet to test against an environment and ensure outputs are correct and types match:

```typescript
export async function commsBufferTest(serverOpts: IOptions) {
  const wu = Workunit.attach(serverOpts, 'W20260226-200207');

  // Existing parsed behavior
  const scopes = await wu.fetchDetails();
  console.log('Parsed scopes:', scopes.length);

  // New raw behavior
  const raw = await wu.fetchDetails(
    { ScopeFilter: { Scopes: ['workunit'] } },
    { bypassResponseParsing: true },
  );
  console.log('Raw bytes:', raw.byteLength);

  const text = new TextDecoder().decode(new Uint8Array(raw));
  const payload = JSON.parse(text);
  console.log('Top level keys:', Object.keys(payload));
}
```

<!-- Thank you for taking the time to submit this pull request and to answer all of the above 
-->